### PR TITLE
fix:dev:NEZ-96 Followup commit to d581772b225e52a10c18f4f9befd872d953…

### DIFF
--- a/plugins/src/main/java/com/qubole/quark/plugins/jdbc/EMRDb.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/jdbc/EMRDb.java
@@ -15,10 +15,13 @@
 
 package com.qubole.quark.plugins.jdbc;
 
+import org.apache.commons.lang.Validate;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Created by dev on 11/16/15.
@@ -29,10 +32,12 @@ public class EMRDb extends HiveDb {
   private Connection connection;
   public String driverName;
 
-  public EMRDb(String jdbcUrl, String url, String user, String password, String driverName) {
-    super(url, user, password);
-    this.jdbcUrl = jdbcUrl;
-    this.driverName = driverName;
+  public EMRDb(Map<String, Object> properties) {
+    super(properties);
+    Validate.notNull(properties.get("driverName"), "Specify field 'driverName' for EMR");
+    Validate.notNull(properties.get("jdbcUrl"), "Specify field 'jdbcUrl' for EMR");
+    this.jdbcUrl = (String) properties.get("jdbcUrl");
+    this.driverName = (String) properties.get("driverName");
   }
 
   public Connection getConnectionExec() throws ClassNotFoundException, SQLException {

--- a/plugins/src/main/java/com/qubole/quark/plugins/jdbc/H2Db.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/jdbc/H2Db.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -51,8 +52,8 @@ public class H2Db extends JdbcDB {
         .put("1", "character")
         .put("91", "date").build();
 
-  public H2Db(String url, String user, String password) {
-    super(url, user, password);
+  public H2Db(Map<String, Object> properties) {
+    super(properties);
   }
 
   public Connection getConnection() throws ClassNotFoundException, SQLException {

--- a/plugins/src/main/java/com/qubole/quark/plugins/jdbc/HiveDb.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/jdbc/HiveDb.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Map;
 
 /**
  * Support Apache Hive database as a {@link com.qubole.quark.plugin.DataSource}
@@ -55,8 +56,8 @@ public class HiveDb extends JdbcDB {
         .put("character\\([0-9]+\\)", "character")
         .put("decimal\\([0-9]+,[0-9]+\\)", "double").build();
 
-  public HiveDb(String url, String user, String password) {
-    super(url, user, password);
+  public HiveDb(Map<String, Object> properties) {
+    super(properties);
   }
 
   public Connection getConnection() throws ClassNotFoundException, SQLException {

--- a/plugins/src/main/java/com/qubole/quark/plugins/jdbc/JdbcDB.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/jdbc/JdbcDB.java
@@ -19,6 +19,8 @@ import org.apache.calcite.runtime.ResultSetEnumerable;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.Table;
 
+import org.apache.commons.lang.Validate;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -39,6 +41,7 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 
 import java.util.Iterator;
+import java.util.Map;
 
 import javax.sql.DataSource;
 /**
@@ -55,10 +58,20 @@ public abstract class JdbcDB implements Executor {
   protected final String user;
   protected final String password;
 
-  JdbcDB(String url, String user, String password) {
-    this.url = url;
-    this.user = user;
-    this.password = password;
+  JdbcDB(Map<String, Object> properties) {
+    validate(properties);
+    this.url = (String) properties.get("url");
+    this.user = (String) properties.get("username");
+    this.password = (String) properties.get("password");
+  }
+
+  private void validate(Map<String, Object> properties) {
+    Validate.notNull(properties.get("url"), "Field \"url\" specifying JDBC endpoint needs "
+        + "to be defined for JDBC Data Source in JSON");
+    Validate.notNull(properties.get("username"), "Field \"username\" specifying username needs "
+        + "to be defined for JDBC Data Source in JSON");
+    Validate.notNull(properties.get("password"), "Field \"password\" specifying password "
+        + "to be defined for JDBC Data Source in JSON");
   }
 
   public ImmutableMap<String, Schema> getSchemas() throws QuarkException {

--- a/plugins/src/main/java/com/qubole/quark/plugins/jdbc/MysqlDb.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/jdbc/MysqlDb.java
@@ -23,6 +23,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Map;
 
 /**
  * Created by dev on 11/23/15.
@@ -56,8 +57,8 @@ public class MysqlDb extends JdbcDB {
   private String defaultSchema = null;
   private final String productName = "MYSQL";
 
-  public MysqlDb(String url, String user, String password) {
-    super(url, user, password);
+  public MysqlDb(Map<String, Object> properties) {
+    super(properties);
   }
 
   @Override

--- a/plugins/src/main/java/com/qubole/quark/plugins/jdbc/OracleDb.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/jdbc/OracleDb.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Map;
 
 /**
  * Created by dev on 11/23/15.
@@ -59,8 +60,8 @@ public class OracleDb extends JdbcDB {
           .put("LONG", "long")
           .build();
 
-  public OracleDb(String url, String user, String password) {
-    super(url, user, password);
+  public OracleDb(Map<String, Object> properties) {
+    super(properties);
   }
 
   @Override

--- a/plugins/src/main/java/com/qubole/quark/plugins/jdbc/RedShiftDb.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/jdbc/RedShiftDb.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -41,8 +42,8 @@ public class RedShiftDb extends JdbcDB {
         .put("double precision", "float")
         .put("character\\([0-9]+\\)", "character").build();
 
-  public RedShiftDb(String url, String user, String password) {
-    super(url, user, password);
+  public RedShiftDb(Map<String, Object> properties) {
+    super(properties);
   }
 
   public Connection getConnection() throws ClassNotFoundException, SQLException {

--- a/plugins/src/main/java/com/qubole/quark/plugins/qubole/DbTapDb.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/qubole/DbTapDb.java
@@ -47,11 +47,12 @@ public class DbTapDb extends QuboleDB {
   private String productName = null;
   private String defaultSchema = null;
 
-  DbTapDb(String endpoint, String token, int dbTapId) {
-    super(endpoint, token);
-    Validate.notNull(dbTapId, "Field \"dbtapid\" specifying Qubole's endpoint needs "
+  public DbTapDb(Map<String, Object> properties) {
+    super(properties);
+    Validate.notNull(properties.get("dbtapid"),
+        "Field \"dbtapid\" specifying Qubole's endpoint needs "
         + "to be defined for Qubole Data Source of type DBTAP in JSON");
-    this.dbTapid = dbTapId;
+    this.dbTapid = Integer.parseInt(properties.get("dbtapid").toString());
   }
 
   @Override

--- a/plugins/src/main/java/com/qubole/quark/plugins/qubole/HiveDb.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/qubole/HiveDb.java
@@ -47,8 +47,8 @@ public class HiveDb extends QuboleDB {
                   .put("character\\([0-9]+\\)", "character")
                   .put("decimal\\([0-9]+,[0-9]+\\)", "double").build();
 
-  HiveDb(String token, String endpoint) {
-    super(token, endpoint);
+  public HiveDb(Map<String, Object> properties) {
+    super(properties);
   }
 
   @Override

--- a/plugins/src/main/java/com/qubole/quark/plugins/qubole/QuboleDB.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/qubole/QuboleDB.java
@@ -18,6 +18,8 @@ package com.qubole.quark.plugins.qubole;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.Table;
 
+import org.apache.commons.lang.Validate;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -62,9 +64,19 @@ public abstract class QuboleDB implements Executor {
   protected String token;
   protected String endpoint;
 
-  QuboleDB(String endpoint, String token) {
-    this.endpoint = endpoint;
-    this.token = token;
+  QuboleDB(Map<String, Object> properties) {
+    validate(properties);
+    this.endpoint = (String) properties.get("endpoint");
+    this.token = (String) properties.get("token");
+  }
+
+  private void validate(Map<String, Object> properties) {
+    Validate.notNull(properties.get("endpoint"),
+        "Field \"endpoint\" specifying Qubole's endpoint needs "
+            + "to be defined for Qubole Data Source in JSON");
+    Validate.notNull(properties.get("token"),
+        "Field \"token\" specifying Authentication token needs "
+            + "to be defined for Qubole Data Source in JSON");
   }
 
   @Override

--- a/plugins/src/main/java/com/qubole/quark/plugins/qubole/QuboleFactory.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/qubole/QuboleFactory.java
@@ -17,42 +17,51 @@ package com.qubole.quark.plugins.qubole;
 
 import org.apache.commons.lang.Validate;
 
+import com.google.common.collect.ImmutableMap;
+
 import com.qubole.quark.QuarkException;
 import com.qubole.quark.plugin.DataSource;
 import com.qubole.quark.plugin.DataSourceFactory;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.Map;
 
 /**
  * Created by dev on 11/13/15.
  */
 public class QuboleFactory implements DataSourceFactory {
+  // Static Registry for Qubole DB plugin
+  private static final Map<String, Class<? extends QuboleDB>> DB_PLUGINS =
+      ImmutableMap.of(
+          "HIVE", HiveDb.class,
+          "DBTAP", DbTapDb.class
+      );
+
   @Override
   public DataSource create(Map<String, Object> properties) throws QuarkException {
 
     Validate.notNull(properties.get("type"),
         "Field \"type\" specifying either HIVE or DBTAP needs "
             + "to be defined for Qubole Data Source in JSON");
-    Validate.notNull(properties.get("endpoint"),
-        "Field \"endpoint\" specifying Qubole's endpoint needs "
-        + "to be defined for Qubole Data Source in JSON");
-    Validate.notNull(properties.get("token"),
-        "Field \"token\" specifying Authentication token needs "
-        + "to be defined for Qubole Data Source in JSON");
+    String type = (String) properties.get("type");
+    Class dbClass = DB_PLUGINS.get(type.toUpperCase());
+    Validate.notNull(dbClass, "Invalid DataSource type: " + type
+        + " Please specify one of these: "
+        + Arrays.toString(DB_PLUGINS.keySet().toArray()));
+    return getDataSource(properties, dbClass);
+  }
 
-    String type = properties.get("type").toString();
-    String token = properties.get("token").toString();
-    String endpoint =  properties.get("endpoint").toString();
-
-    if (type.toUpperCase().equals("HIVE")) {
-      return new HiveDb(endpoint, token);
-    } else if (type.toUpperCase().equals("DBTAP")) {
-      Validate.notNull(properties.get("dbtapid"),
-          "Field \"dbtapid\" needs to be defined for Qubole Data Source in JSON");
-      return new DbTapDb(endpoint, token, Integer.parseInt(properties.get("dbtapid").toString()));
-    } else {
-      throw new QuarkException(new Throwable("Invalid qubole DataSource type:" + type
-          + "\nCurrently supporting either HIVE or DBTAP"));
+  private DataSource getDataSource(Map<String, Object> properties,
+                                   Class dbClass) throws QuarkException {
+    try {
+      return (DataSource) (dbClass.getConstructor(Map.class)
+          .newInstance(properties));
+    } catch (NoSuchMethodException | IllegalAccessException | InstantiationException e) {
+      throw new QuarkException(new Throwable("Invoking invalid constructor on class "
+          + "specified for type " + properties.get("type") + ": " + dbClass.getCanonicalName()));
+    } catch (InvocationTargetException e) {
+      throw new QuarkException(e.getTargetException());
     }
   }
 }

--- a/plugins/src/test/java/com/qubole/quark/plugins/jdbc/QuboleFactoryValidationTest.java
+++ b/plugins/src/test/java/com/qubole/quark/plugins/jdbc/QuboleFactoryValidationTest.java
@@ -23,7 +23,7 @@ public class QuboleFactoryValidationTest {
     factory.create(props);
   }
 
-  @Test(expected = QuarkException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void testInvalidType() throws QuarkException{
     Map<String, Object> props = new HashMap<>();
     props.put("type", "h4");
@@ -71,7 +71,7 @@ public class QuboleFactoryValidationTest {
     factory.create(props);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = QuarkException.class)
   public void testDbTapIdNull() throws QuarkException{
     Map<String, Object> props = new HashMap<>();
     props.put("type", "dbtap");


### PR DESCRIPTION
…4a653

Earlier commit broke EMR. Fixing it by:
1. Make Factory classes agnostic of plugins except the registry it
maintains of the supported plugins.
2. Parsing of properties and their validations will be taken care by
plugins instead of Factory classes, thereby decoupling Factory

Integration Test:
http://karma.qubole.net/job/Quark/108/