### PR TITLE
Add cluster for Materialized Views that allows change of planner.

### DIFF
--- a/optimizer/src/main/java/com/qubole/quark/sql/SqlWorker.java
+++ b/optimizer/src/main/java/com/qubole/quark/sql/SqlWorker.java
@@ -27,6 +27,7 @@ import org.apache.calcite.interpreter.Bindables;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.materialize.MaterializationService;
 import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.QuarkMaterializeCluster;
 import org.apache.calcite.plan.RelOptLattice;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptRule;
@@ -94,10 +95,12 @@ public class SqlWorker {
 
   private final QueryContext context;
   private final CalciteCatalogReader catalogReader;
+  private final QuarkMaterializeCluster.RelOptPlannerHolder plannerHolder;
 
   public SqlWorker(QueryContext context) {
     this.context = context;
     this.catalogReader = createCatalogReader(context);
+    this.plannerHolder = new QuarkMaterializeCluster.RelOptPlannerHolder(null);
     this.planner = buildPlanner(context);
   }
 
@@ -143,7 +146,7 @@ public class SqlWorker {
         = ImmutableList.builder();
     for (RuleSet ruleSet: getRules()) {
       builder.add(Programs.sequence(
-          new EnumerableProgram(ruleSet, this.context),
+          new EnumerableProgram(ruleSet, this.context, this.plannerHolder),
           Programs.CALC_PROGRAM));
     }
     return builder.build();
@@ -157,9 +160,13 @@ public class SqlWorker {
     final QueryContext context;
     final MaterializationService materializationService
         = MaterializationService.instance();
-    private EnumerableProgram(RuleSet ruleSet, QueryContext context) {
+    final QuarkMaterializeCluster.RelOptPlannerHolder plannerHolder;
+    List<Prepare.Materialization> materializations = null;
+    private EnumerableProgram(RuleSet ruleSet, QueryContext context,
+                              QuarkMaterializeCluster.RelOptPlannerHolder holder) {
       this.ruleSet = ruleSet;
       this.context = context;
+      this.plannerHolder = holder;
     }
 
     public RelNode run(RelOptPlanner planner, RelNode rel,
@@ -186,8 +193,8 @@ public class SqlWorker {
       planner.setRoot(rel);
 
       MaterializationService.setThreadLocal(materializationService);
-      populateMaterializationsAndLattice(planner, rootSchema);
-
+      plannerHolder.setPlanner(planner);
+      populateMaterializationsAndLattice(plannerHolder, rootSchema);
       if (!rel.getTraitSet().equals(requiredOutputTraits)) {
         rel = planner.changeTraits(rel, requiredOutputTraits);
         planner.setRoot(rel);
@@ -197,19 +204,18 @@ public class SqlWorker {
       return planner2.findBestExp();
     }
 
-    private void populateMaterializationsAndLattice(RelOptPlanner planner,
-                                                    CalciteSchema rootSchema) {
-      Materializer materializer = new Materializer();
-      final List<Prepare.Materialization> materializations =
-          MaterializationService.instance().query(rootSchema);
-
-      for (Prepare.Materialization materialization : materializations) {
-        materializer.populateMaterializations(context.getPrepareContext(),
-            planner, materialization);
+    private void populateMaterializationsAndLattice(
+        QuarkMaterializeCluster.RelOptPlannerHolder plannerHolder,
+        CalciteSchema rootSchema) {
+      if (materializations == null) {
+        materializations =
+            MaterializationService.instance().query(rootSchema);
       }
+      Materializer materializer = new Materializer(materializations);
 
-      final List<CalciteSchema.LatticeEntry> lattices =
-          Schemas.getLatticeEntries(rootSchema);
+      materializer.populateMaterializations(context.getPrepareContext(), plannerHolder);
+
+      List<CalciteSchema.LatticeEntry> lattices = Schemas.getLatticeEntries(rootSchema);
 
       for (CalciteSchema.LatticeEntry lattice : lattices) {
         final CalciteSchema.TableEntry starTable = lattice.getStarTable();
@@ -217,7 +223,7 @@ public class SqlWorker {
         final RelOptTableImpl starRelOptTable =
             RelOptTableImpl.create(catalogReader,
                 starTable.getTable().getRowType(typeFactory), starTable, null);
-        planner.addLattice(
+        plannerHolder.getPlanner().addLattice(
             new RelOptLattice(lattice.getLattice(), starRelOptTable));
       }
     }

--- a/optimizer/src/main/java/org/apache/calcite/plan/QuarkMaterializeCluster.java
+++ b/optimizer/src/main/java/org/apache/calcite/plan/QuarkMaterializeCluster.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2015. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.calcite.plan;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Cluster that allows change of {@link RelOptPlanner}.
+ *
+ * This Cluster is used to optimize populating Materialized views in {@link RelOptPlanner}
+ * and should be used only in {@link RelNode} of Materialized views.
+ * Populating materialized views requires parsing of sql string representing
+ * materialized views and this can be very expensive. To optimize, for a
+ * {@link com.qubole.quark.planner.Parser} object all view Sql strings are
+ * parsed only once and cached. However, caching doesn't work as every new parse
+ * creates new {@link RelOptPlanner} which does not accept cached {@link RelNode}
+ * created using dofferent planner.
+ * If cached {@link RelNode} consists of QuarkMaterializedCluster then
+ * we change the planner to the new planner and then it can accept cached
+ * {@link RelNode}.
+ */
+public class QuarkMaterializeCluster extends RelOptCluster {
+  final RelOptPlannerHolder plannerHolder;
+
+  /**
+   * Creates a cluster.
+   *
+   * <p>For use only from {@link #create}.
+   */
+  QuarkMaterializeCluster(RelOptPlannerHolder plannerHolder,
+                          RelDataTypeFactory typeFactory,
+                          RexBuilder rexBuilder, AtomicInteger nextCorrel,
+                          Map<String, RelNode> mapCorrelToRel) {
+    super(plannerHolder.getPlanner(), typeFactory, rexBuilder, nextCorrel, mapCorrelToRel);
+    this.plannerHolder = plannerHolder;
+  }
+  /** Creates a cluster. */
+  public static QuarkMaterializeCluster create(RelOptPlannerHolder plannerHolder,
+                                     RexBuilder rexBuilder) {
+    return new QuarkMaterializeCluster(plannerHolder, rexBuilder.getTypeFactory(),
+        rexBuilder, new AtomicInteger(0), new HashMap<String, RelNode>());
+  }
+  public RelOptPlanner getPlanner() {
+    return plannerHolder.getPlanner();
+  }
+  /** Returns the default trait set for this cluster. */
+  public RelTraitSet traitSet() {
+    return getPlanner().emptyTraitSet();
+  }
+
+  public RelTraitSet traitSetOf(RelTrait trait) {
+    return traitSet().replace(trait);
+  }
+
+  /**
+   * Holder for {@link RelOptPlanner}
+   */
+  public static class RelOptPlannerHolder {
+    private RelOptPlanner planner;
+
+    public RelOptPlannerHolder(RelOptPlanner planner) {
+      this.planner = planner;
+    }
+
+    public RelOptPlanner getPlanner() {
+      return planner;
+    }
+
+    public void setPlanner(RelOptPlanner planner) {
+      this.planner = planner;
+    }
+  }
+}
+
+


### PR DESCRIPTION
This Cluster is used to optimize populating Materialized views in
planner and should be used only in the {@link RelNode} of
Materialized views.Populating materialized views requires
parsing of sql string representing materialized views and this
can be very expensive. To optimize, for a
{@link com.qubole.quark.planner.Parser} object all view Sql
strings are parsed only once and cached. However, caching
doesnot work as every new parse creates new planner which does not
accept cached {@link RelNode} created on different planner.
If cached {@link RelNode} consists of QuarkMaterializedCluster
then we change Cluster's planner to the new planner and then it can
accept cached {@link RelNode}.