### PR TITLE
Throw SQLException for Syntax and Semantic Errors

### DIFF
--- a/jdbc/src/test/java/com/qubole/quark/jdbc/test/integration/ErrorsIntegTest.java
+++ b/jdbc/src/test/java/com/qubole/quark/jdbc/test/integration/ErrorsIntegTest.java
@@ -1,0 +1,48 @@
+package com.qubole.quark.jdbc.test.integration;
+
+import com.qubole.quark.jdbc.test.integration.utility.IntegTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Created by rajatv on 1/28/16.
+ */
+public class ErrorsIntegTest extends IntegTest {
+  public static final String h2Url = "jdbc:h2:mem:SimpleTest;DB_CLOSE_DELAY=-1";
+  public static final String viewUrl = "jdbc:h2:mem:SimpleViews;DB_CLOSE_DELAY=-1";
+  public static Connection conn;
+
+  @BeforeClass
+  public static void setUpClass() throws ClassNotFoundException, SQLException,
+      IOException, URISyntaxException {
+    setupTables(h2Url, "tpcds.sql");
+    setupTables(viewUrl, "tpcds_views.sql");
+
+    Class.forName("com.qubole.quark.jdbc.QuarkDriver");
+    conn = DriverManager.getConnection("jdbc:quark:"
+        + TpcdsIntegTest.class.getResource("/SimpleModel.json").getPath(), new Properties());
+  }
+
+  @Test
+  public void testSyntaxError() throws SQLException, ClassNotFoundException {
+    String query = "select count(*) canonical.public.web_returns";
+    assertThatThrownBy(() -> conn.createStatement().executeQuery(query)).isInstanceOf(SQLException.class)
+        .hasMessageContaining("Encountered \".\" at line 1, column 26.");
+  }
+
+  @Test
+  public void testSemanticError() throws SQLException, ClassNotFoundException {
+    String query = "select count(*) from canonical.public.web_rturns";
+    assertThatThrownBy(() -> conn.createStatement().executeQuery(query)).isInstanceOf(SQLException.class)
+        .hasMessageContaining("Table 'CANONICAL.PUBLIC.WEB_RTURNS' not found");
+  }
+}

--- a/jdbc/src/test/resources/ErrorsModel.json
+++ b/jdbc/src/test/resources/ErrorsModel.json
@@ -1,0 +1,22 @@
+{
+  "dataSources": [
+    {
+      "name": "CANONICAL",
+      "default": "true",
+      "password": "",
+      "factory": "com.qubole.quark.plugins.jdbc.JdbcFactory",
+      "type": "H2",
+      "url": "jdbc:h2:mem:ErrorTest;DB_CLOSE_DELAY=-1",
+      "username": "sa"
+    },
+    {
+      "name": "VIEWS",
+      "password": "",
+      "type": "H2",
+      "factory": "com.qubole.quark.plugins.jdbc.JdbcFactory",
+      "url": "jdbc:h2:mem:ErrorViews;DB_CLOSE_DELAY=-1",
+      "username": "sa",
+      "default" : "false"
+    }
+  ]
+}

--- a/optimizer/src/main/java/com/qubole/quark/planner/Parser.java
+++ b/optimizer/src/main/java/com/qubole/quark/planner/Parser.java
@@ -218,9 +218,6 @@ public class Parser {
         final String stripNamespace = stripNamespace(sql, newDataSource);
         result = new ParserResult(stripNamespace, newDataSource, kind, relNode, true);
       } else if (this.context.isUnitTestMode()) {
-        /**
-         *  No default datasource set, so just send back parsed sql
-         */
         String parsedSql =
             getParsedSql(relNode,
                 new SqlDialect(SqlDialect.DatabaseProduct.UNKNOWN, "UNKNOWN", null, true));
@@ -228,14 +225,10 @@ public class Parser {
       } else if (dataSources.size() > 1) {
         /**
          * Check if it's partially optimized, i.e., tablescans of multiple datasources
-         * are found in RelNode. We currently donot support multiple datasources,
-         * so send back the original query stored in result by updating relNode.
+         * are found in RelNode. We currently donot support multiple datasources.
          */
         throw new SQLException("Federation between data sources is not allowed", "0A001");
       } else if (dataSources.isEmpty()) {
-        /**
-         *  No datasource found, so just send back parsed sql
-         */
         throw new SQLException("No dataSource found for query", "3D001");
       }
       return result;

--- a/optimizer/src/main/java/com/qubole/quark/sql/QueryContext.java
+++ b/optimizer/src/main/java/com/qubole/quark/sql/QueryContext.java
@@ -55,6 +55,7 @@ public class QueryContext {
   protected static final Logger LOG = LoggerFactory.getLogger(QueryContext.class);
   private final SchemaPlus rootSchema = CalciteSchema.createRootSchema(true).plus();
   private DataSourceSchema defaultDataSource;
+  private boolean unitTestMode;
   private final List<String> defaultSchema;
   private final Class schemaFactoryClazz;
   private final Properties info;
@@ -97,6 +98,7 @@ public class QueryContext {
       final RelDataTypeSystem typeSystem =
           cfg.typeSystem(RelDataTypeSystem.class, RelDataTypeSystem.DEFAULT);
       this.typeFactory = new JavaTypeFactoryImpl(typeSystem);
+      this.unitTestMode = Boolean.parseBoolean(info.getProperty("unitTestMode", "false"));
 
       Object obj = schemaFactoryClazz.newInstance();
       if (obj instanceof QuarkFactory) {
@@ -201,5 +203,9 @@ public class QueryContext {
 
   public DataSourceSchema getDefaultDataSource() {
     return defaultDataSource;
+  }
+
+  public boolean isUnitTestMode() {
+    return unitTestMode;
   }
 }

--- a/optimizer/src/main/java/com/qubole/quark/sql/handlers/EnumerableSqlHandler.java
+++ b/optimizer/src/main/java/com/qubole/quark/sql/handlers/EnumerableSqlHandler.java
@@ -57,14 +57,10 @@ public class EnumerableSqlHandler implements SqlHandler<RelNode, String> {
     } catch (ClassNotFoundException e) {
       throw new RuntimeException("Error loading calcite Driver: " + e.getMessage(), e);
     } catch (SqlParseException e) {
-      LOGGER.error("SqlParsing failed: " + e.getMessage(), e);
       throw new RuntimeException("SqlParsing failed: " + e.getMessage(), e);
     } catch (ValidationException e) {
-      LOGGER.error("Sql Validation failed: " + e.getMessage(), e);
       throw new RuntimeException("Sql Validation failed: " + e.getMessage(), e);
     } catch (RelConversionException e) {
-      LOGGER.error("Sql to RelNode conversion or transformation failed: "
-          + e.getMessage(), e);
       throw new RuntimeException("Sql to RelNode conversion or transformation failed: "
           + e.getMessage(), e);
     }

--- a/optimizer/src/test/java/com/qubole/quark/planner/test/LatticeTest.java
+++ b/optimizer/src/test/java/com/qubole/quark/planner/test/LatticeTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Properties;
 
@@ -154,6 +155,7 @@ public class LatticeTest {
   @BeforeClass
   public static void setUpClass() throws Exception {
     info = new Properties();
+    info.put("unitTestMode", "true");
     info.put("schemaFactory", "com.qubole.quark.planner.test.LatticeTest$SchemaFactory");
 
     ImmutableList<String> defaultSchema = ImmutableList.of("FOODMART");
@@ -163,7 +165,7 @@ public class LatticeTest {
   }
 
   @Test
-  public void testSimple() throws QuarkException {
+  public void testSimple() throws QuarkException, SQLException {
     Parser parser = new Parser(info);
     Parser.ParserResult result = parser.parse("select * from account");
     List<String> usedTables = parser.getTables(result.getRelNode());
@@ -172,7 +174,7 @@ public class LatticeTest {
   }
 
   @Test
-  public void testCountFact() throws QuarkException {
+  public void testCountFact() throws QuarkException, SQLException {
     final String sql = "select t.the_year, "
         + "  sum(s.unit_sales)  "
         + "from foodmart.sales_fact_1997 as s "
@@ -189,7 +191,7 @@ public class LatticeTest {
   }
 
   @Test
-  public void testWebReturns() throws QuarkException {
+  public void testWebReturns() throws QuarkException, SQLException {
     final String sql = "select dd.d_year, "
         + "  sum(wr_net_loss)  "
         + "from tpcds.web_returns as w "
@@ -206,7 +208,7 @@ public class LatticeTest {
   }
 
   @Test
-  public void storeFilterQuery() throws QuarkException {
+  public void storeFilterQuery() throws QuarkException, SQLException {
     String sql = "select d_year, d_qoy, cd_gender, sum(ss_sales_price) " +
         " from tpcds.store_sales join tpcds.date_dim on ss_sold_date_sk = d_date_sk " +
         " join tpcds.customer_demographics on ss_cdemo_sk = cd_demo_sk " +
@@ -226,7 +228,7 @@ public class LatticeTest {
    * aggregate is used to remove the filter column.
    */
   @Test
-  public void storeFilterQuery2() throws QuarkException {
+  public void storeFilterQuery2() throws QuarkException, SQLException {
       String sql = "select d_year, d_qoy, sum(ss_sales_price) " +
           " from tpcds.store_sales join tpcds.date_dim on ss_sold_date_sk = d_date_sk " +
           " join tpcds.customer_demographics on ss_cdemo_sk = cd_demo_sk " +

--- a/optimizer/src/test/java/com/qubole/quark/planner/test/MetricsTest.java
+++ b/optimizer/src/test/java/com/qubole/quark/planner/test/MetricsTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -115,6 +116,7 @@ public class MetricsTest {
   @BeforeClass
   public static void setUpClass() throws Exception {
     info = new Properties();
+    info.put("unitTestMode", "true");
     info.put("schemaFactory", "com.qubole.quark.planner.test.MetricsTest$SchemaFactory");
     info.put("materializationsEnabled", "true");
 
@@ -122,7 +124,7 @@ public class MetricsTest {
   }
 
   @Test
-  public void testViewFilter() throws QuarkException {
+  public void testViewFilter() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedSql(
         "select name, value from metrics_schema.metrics where name='FileSystemCounters.S3_READ_OPS'",
         info,

--- a/optimizer/src/test/java/com/qubole/quark/planner/test/QueryTest.java
+++ b/optimizer/src/test/java/com/qubole/quark/planner/test/QueryTest.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 /**
  * Created by rajatv on 2/6/15.
@@ -156,18 +156,24 @@ public class QueryTest {
   @Test
   public void testSyntaxError() throws QuarkException, SQLException {
     Parser parser = new Parser(info);
-
-    assertThatThrownBy(() -> parser.parse("select count(*) test.many_columns where " +
-        "test.many_columns.j > 100 and test.many_columns.i = 10")).isInstanceOf(SQLException.class)
-        .hasMessageContaining("Encountered \".\" at line 1, column 21.");
+    try {
+      parser.parse("select count(*) test.many_columns where " +
+          "test.many_columns.j > 100 and test.many_columns.i = 10");
+      failBecauseExceptionWasNotThrown(SQLException.class);
+    } catch (SQLException e) {
+      assertThat((Throwable) e).hasMessageContaining("Encountered \".\" at line 1, column 21.");
+    }
   }
 
   @Test
   public void testSemanticError() throws QuarkException, SQLException {
     Parser parser = new Parser(info);
-
-    assertThatThrownBy(() -> parser.parse("select count(*) from test.many_colum where " +
-        "test.many_columns.j > 100 and test.many_columns.i = 10")).isInstanceOf(SQLException.class)
-        .hasMessageContaining("Table 'TEST.MANY_COLUM' not found");
+    try {
+      parser.parse("select count(*) from test.many_colum where " +
+          "test.many_columns.j > 100 and test.many_columns.i = 10");
+      failBecauseExceptionWasNotThrown(SQLException.class);
+    } catch (SQLException e) {
+      assertThat((Throwable) e).hasMessageContaining("Table 'TEST.MANY_COLUM' not found");
+    }
   }
 }

--- a/optimizer/src/test/java/com/qubole/quark/planner/test/QueryTest.java
+++ b/optimizer/src/test/java/com/qubole/quark/planner/test/QueryTest.java
@@ -34,6 +34,7 @@ import com.qubole.quark.planner.test.utilities.QuarkTestUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Created by rajatv on 2/6/15.
@@ -90,6 +92,7 @@ public class QueryTest {
   @BeforeClass
   public static void setUpClass() throws Exception {
     info = new Properties();
+    info.put("unitTestMode", "true");
     info.put("defaultSchema", QuarkTestUtil.toJson("TEST"));
     info.put("schemaFactory", "com.qubole.quark.planner.test.QueryTest$SchemaFactory");
     info.put("model",
@@ -109,7 +112,7 @@ public class QueryTest {
   }
 
   @Test
-  public void testParse() throws QuarkException {
+  public void testParse() throws QuarkException, SQLException {
     Parser parser = new Parser(info);
     RelNode relNode = parser.parse("select * from simple").getRelNode();
     List<String> usedTables = parser.getTables(relNode);
@@ -118,7 +121,7 @@ public class QueryTest {
   }
 
   @Test
-  public void testFilter() throws QuarkException {
+  public void testFilter() throws QuarkException, SQLException {
     Parser parser = new Parser(info);
 
     Parser.ParserResult result =
@@ -133,7 +136,7 @@ public class QueryTest {
   }
 
   @Test
-  public void testTwoFilter() throws QuarkException {
+  public void testTwoFilter() throws QuarkException, SQLException {
     Parser parser = new Parser(info);
 
     Parser.ParserResult result =
@@ -148,5 +151,23 @@ public class QueryTest {
         result.getParsedSql()
             .equals("SELECT COUNT(*) FROM TEST.MANY_COLUMNS WHERE J > 100 AND I = 10")
     );
+  }
+
+  @Test
+  public void testSyntaxError() throws QuarkException, SQLException {
+    Parser parser = new Parser(info);
+
+    assertThatThrownBy(() -> parser.parse("select count(*) test.many_columns where " +
+        "test.many_columns.j > 100 and test.many_columns.i = 10")).isInstanceOf(SQLException.class)
+        .hasMessageContaining("Encountered \".\" at line 1, column 21.");
+  }
+
+  @Test
+  public void testSemanticError() throws QuarkException, SQLException {
+    Parser parser = new Parser(info);
+
+    assertThatThrownBy(() -> parser.parse("select count(*) from test.many_colum where " +
+        "test.many_columns.j > 100 and test.many_columns.i = 10")).isInstanceOf(SQLException.class)
+        .hasMessageContaining("Table 'TEST.MANY_COLUM' not found");
   }
 }

--- a/optimizer/src/test/java/com/qubole/quark/planner/test/RelToSqlConverterTest.java
+++ b/optimizer/src/test/java/com/qubole/quark/planner/test/RelToSqlConverterTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -53,6 +54,7 @@ public class RelToSqlConverterTest {
   @BeforeClass
   public static void setUpClass() throws Exception {
     info = new Properties();
+    info.put("unitTestMode", "true");
     info.put("defaultSchema", QuarkTestUtil.toJson("FOODMART"));
     info.put("schemaFactory", "com.qubole.quark.planner.test.RelToSqlConverterTest$SchemaFactory");
 
@@ -62,7 +64,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSimpleSelectQueryFromProductTable() throws QuarkException {
+  public void testSimpleSelectQueryFromProductTable() throws QuarkException, SQLException {
     String query = "select product_id from product";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -71,7 +73,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSimpleSelectQueryFromCategoryTable() throws QuarkException {
+  public void testSimpleSelectQueryFromCategoryTable() throws QuarkException, SQLException {
     String query = "select category_id from category";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -80,7 +82,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectTwoColumnQuery() throws QuarkException {
+  public void testSelectTwoColumnQuery() throws QuarkException, SQLException {
     String query = "select product_id, product_class_id from product";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -91,7 +93,7 @@ public class RelToSqlConverterTest {
   //TODO: add test for query -> select * from product
 
   @Test
-  public void testSelectQueryWithWhereClauseOfLessThan() throws QuarkException {
+  public void testSelectQueryWithWhereClauseOfLessThan() throws QuarkException, SQLException {
     String query = "select product_id, shelf_width from product where product_id < 10";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -103,7 +105,7 @@ public class RelToSqlConverterTest {
 
   //This test also produces operand product_id which is casted to integer.
   @Test
-  public void testSelectQueryWithWhereClauseOfEqual() throws QuarkException {
+  public void testSelectQueryWithWhereClauseOfEqual() throws QuarkException, SQLException {
     String query = "select product_id, shelf_width from product where product_id = 10";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -113,7 +115,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithWhereClauseofGreaterThan() throws QuarkException {
+  public void testSelectQueryWithWhereClauseofGreaterThan() throws QuarkException, SQLException {
     String query = "select product_id, shelf_width from product where product_id > 10";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -124,7 +126,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithWhereClauseofLessThanEqualTo() throws QuarkException {
+  public void testSelectQueryWithWhereClauseofLessThanEqualTo() throws QuarkException, SQLException {
     String query = "select product_id, shelf_width from product where product_id <= 10";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -135,7 +137,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithWhereClauseofGreaterThanEqualTo() throws QuarkException {
+  public void testSelectQueryWithWhereClauseofGreaterThanEqualTo() throws QuarkException, SQLException {
     String query = "select product_id, shelf_width from product where product_id >= 10";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -146,7 +148,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithWhereClauseWithExpressionFirst() throws QuarkException {
+  public void testSelectQueryWithWhereClauseWithExpressionFirst() throws QuarkException, SQLException {
     String query = "select product_id, shelf_width from product where 10 < product_id";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -157,7 +159,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithGroupBy() throws QuarkException {
+  public void testSelectQueryWithGroupBy() throws QuarkException, SQLException {
     String query = "select count(*) from product group by product_class_id, product_id "; //having net_weight > 100";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -168,7 +170,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithMinAggregateFunction() throws QuarkException {
+  public void testSelectQueryWithMinAggregateFunction() throws QuarkException, SQLException {
     String query = "select min(net_weight) from product group by product_class_id ";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -179,7 +181,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithMinAggregateFunction1() throws QuarkException {
+  public void testSelectQueryWithMinAggregateFunction1() throws QuarkException, SQLException {
     String query = "select PRODUCT_CLASS_ID, min(net_weight) from product group by product_class_id ";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -190,7 +192,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithSumAggregateFunction() throws QuarkException {
+  public void testSelectQueryWithSumAggregateFunction() throws QuarkException, SQLException {
     String query = "select sum(net_weight) from product group by product_class_id ";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -201,7 +203,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithMultipleAggregateFunction() throws QuarkException {
+  public void testSelectQueryWithMultipleAggregateFunction() throws QuarkException, SQLException {
     String query = "select sum(net_weight), min(low_fat), count(*) from product group by product_class_id ";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -212,7 +214,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithMultipleAggregateFunction1() throws QuarkException {
+  public void testSelectQueryWithMultipleAggregateFunction1() throws QuarkException, SQLException {
     String query = "select product_class_id, sum(net_weight), min(low_fat), count(*) from product group by product_class_id ";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -223,7 +225,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithGroupByAndProjectList() throws QuarkException {
+  public void testSelectQueryWithGroupByAndProjectList() throws QuarkException, SQLException {
     String query = "select product_class_id, product_id, count(*) from product group by product_class_id, product_id "; //having net_weight > 100";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -234,7 +236,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithGroupByAndProjectList1() throws QuarkException {
+  public void testSelectQueryWithGroupByAndProjectList1() throws QuarkException, SQLException {
     String query = "select count(*)  from product group by product_class_id, product_id "; //having net_weight > 100";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -256,7 +258,7 @@ public class RelToSqlConverterTest {
 //  }
 
   @Test
-  public void testSelectQueryWithOrderByClause() throws QuarkException {
+  public void testSelectQueryWithOrderByClause() throws QuarkException, SQLException {
     String query = "select product_id from product order by net_weight";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -267,7 +269,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithOrderByClause1() throws QuarkException {
+  public void testSelectQueryWithOrderByClause1() throws QuarkException, SQLException {
     String query = "select product_id, net_weight from product order by net_weight";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -278,7 +280,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithTwoOrderByClause() throws QuarkException {
+  public void testSelectQueryWithTwoOrderByClause() throws QuarkException, SQLException {
     String query = "select product_id from product order by net_weight, gross_weight";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -289,7 +291,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithTwoOrderByClause1() throws QuarkException {
+  public void testSelectQueryWithTwoOrderByClause1() throws QuarkException, SQLException {
     String query = "select product_id, net_weight from product order by net_weight, gross_weight";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -300,7 +302,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithAscDescOrderByClause() throws QuarkException {
+  public void testSelectQueryWithAscDescOrderByClause() throws QuarkException, SQLException {
     String query = "select product_id from product order by net_weight asc, gross_weight desc, low_fat";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -311,7 +313,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithAscDescOrderByClause1() throws QuarkException {
+  public void testSelectQueryWithAscDescOrderByClause1() throws QuarkException, SQLException {
     String query = "select product_id, net_weight, gross_weight from product order by net_weight asc, gross_weight desc, low_fat";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -322,7 +324,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithLimitClause() throws QuarkException {
+  public void testSelectQueryWithLimitClause() throws QuarkException, SQLException {
     String query = "select product_id from product limit 100 offset 10";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -333,7 +335,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSqlParsingOfLimitClauseForRedShift() throws QuarkException, SqlParseException {
+  public void testSqlParsingOfLimitClauseForRedShift() throws QuarkException, SQLException, SqlParseException {
     String query = "select product_id from product limit 100 offset 10";
     final SqlDialect redshiftDialect =
         SqlDialect.getProduct("REDSHIFT", null).getDialect();
@@ -348,7 +350,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryComplex() throws QuarkException {
+  public void testSelectQueryComplex() throws QuarkException, SQLException {
     String query = "select count(*) from product where cases_per_pallet > 100 group by product_id, units_per_case order by units_per_case desc";//, units_per_case, net_weight ";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -361,7 +363,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryComplex1() throws QuarkException {
+  public void testSelectQueryComplex1() throws QuarkException, SQLException {
     String query = "select count(*), units_per_case, product_id from product where cases_per_pallet > 100 group by product_id, units_per_case order by units_per_case desc";//, units_per_case, net_weight ";
     QuarkTestUtil.checkParsedSql(
         query,
@@ -374,7 +376,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithGroup() throws QuarkException {
+  public void testSelectQueryWithGroup() throws QuarkException, SQLException {
     String query = "select count(*), sum(employee_id) from RESERVE_EMPLOYEE where hire_date > '2015-01-01' "
         + "and (position_title = 'SDE' or position_title = 'SDM') group by store_id, position_title";//, units_per_case, net_weight ";
     QuarkTestUtil.checkParsedSql(
@@ -387,7 +389,7 @@ public class RelToSqlConverterTest {
   }
 
   @Test
-  public void testSelectQueryWithGroup1() throws QuarkException {
+  public void testSelectQueryWithGroup1() throws QuarkException, SQLException {
     String query = "select count(*), sum(employee_id), POSITION_TITLE, STORE_ID from RESERVE_EMPLOYEE where hire_date > '2015-01-01' "
         + "and (position_title = 'SDE' or position_title = 'SDM') group by store_id, position_title";//, units_per_case, net_weight ";
     QuarkTestUtil.checkParsedSql(

--- a/optimizer/src/test/java/com/qubole/quark/planner/test/SchemaTest.java
+++ b/optimizer/src/test/java/com/qubole/quark/planner/test/SchemaTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -220,6 +221,7 @@ public class SchemaTest {
   @BeforeClass
   public static void setUpClass() throws Exception {
     info = new Properties();
+    info.put("unitTestMode", "true");
     info.put("schemaFactory", "com.qubole.quark.planner.test.SchemaTest$SchemaFactory");
     info.put("materializationsEnabled", "true");
 
@@ -229,7 +231,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testSimple() throws QuarkException {
+  public void testSimple() throws QuarkException, SQLException {
     Parser parser = new Parser(info);
     List<String> usedTables =
         parser.getTables(parser.parse("select * from simple").getRelNode());
@@ -238,7 +240,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testDefaultSimple() throws QuarkException {
+  public void testDefaultSimple() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedSql(
         "select * from default.simple",
         info,
@@ -246,7 +248,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testTpchNation() throws QuarkException {
+  public void testTpchNation() throws QuarkException, SQLException {
     Parser parser = new Parser(info);
     RelNode relNode = parser.parse("select * from tpch.nation").getRelNode();
     List<String> usedTables = parser.getTables(relNode);
@@ -255,7 +257,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testTpchAsDefault() throws QuarkException, JsonProcessingException {
+  public void testTpchAsDefault() throws QuarkException, SQLException, JsonProcessingException {
     info.put("defaultSchema", QuarkTestUtil.toJson("TPCH"));
     try {
       Parser parser = new Parser(info);
@@ -268,7 +270,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testDefaultNation() throws QuarkException {
+  public void testDefaultNation() throws QuarkException, SQLException {
     Parser parser = new Parser(info);
     RelNode relNode = parser.parse("select * from tpch.nation").getRelNode();
     List<String> usedTables = parser.getTables(relNode);
@@ -279,7 +281,7 @@ public class SchemaTest {
   //TODO: Check this regression
   @Ignore("Regression in calcite. Need to check")
   @Test
-  public void testView100() throws QuarkException {
+  public void testView100() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedSql(
         "select p_name from tpch.part where p_size = 110",
         info,
@@ -287,7 +289,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testViewPartless110() throws QuarkException {
+  public void testViewPartless110() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedSql(
         "select p_name from tpch.part where p_size < 110",
         info,
@@ -295,7 +297,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testViewGreater110() throws QuarkException {
+  public void testViewGreater110() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedSql(
         "select p_name from tpch.part where p_size > 110",
         info,
@@ -303,7 +305,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testViewGreater120() throws QuarkException {
+  public void testViewGreater120() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedSql(
         "select p_name from tpch.part where p_size > 120",
         info,
@@ -311,7 +313,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testViewSALES_greaterDate() throws QuarkException {
+  public void testViewSALES_greaterDate() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedSql(
         "select p_salesid from tpch.sales where p_saledate > \'2016-10-07\'",
         info,
@@ -320,7 +322,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testViewPART_RETAILPRICE() throws QuarkException {
+  public void testViewPART_RETAILPRICE() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedSql(
         "select p_name from tpch.part where p_retailprice > 110.0",
         info,
@@ -329,7 +331,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testViewPART_COMP1_test1() throws QuarkException {
+  public void testViewPART_COMP1_test1() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedRelString(
         "select p_name from tpch.part where (p_retailprice > 20.0 AND p_size > 75)",
         info,
@@ -339,7 +341,7 @@ public class SchemaTest {
 
 
   @Test
-  public void testViewPART_COMP1_test2() throws QuarkException {
+  public void testViewPART_COMP1_test2() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedRelString(
         "select p_name from tpch.part where (20.0 < p_retailprice  AND 80 < p_size)",
         info,
@@ -348,7 +350,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testViewPART_COMP1_test3() throws QuarkException {
+  public void testViewPART_COMP1_test3() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedRelString(
         "select p_name from tpch.part where (20.0 < p_retailprice  AND 80 < p_size " +
             "AND p_name = 'quark')",
@@ -358,7 +360,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testViewPART_COMP1_NegativeTest1() throws QuarkException {
+  public void testViewPART_COMP1_NegativeTest1() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedRelString(
         "select p_name from tpch.part where (p_retailprice > 20.0 OR p_size > 500)",
         info,
@@ -367,7 +369,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testViewPART_COMP1_NegativeTest2() throws QuarkException {
+  public void testViewPART_COMP1_NegativeTest2() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedRelString(
         "select p_name from tpch.part where (p_retailprice > (2.0 + 10.0) OR p_size > 500)",
         info,
@@ -376,7 +378,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testViewPART_COMP1_NegativeTest3() throws QuarkException {
+  public void testViewPART_COMP1_NegativeTest3() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedRelString(
         "select p_name from tpch.part where p_size < 500",
         info,
@@ -385,7 +387,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testViewPART_COMP1_NegativeTest4() throws QuarkException {
+  public void testViewPART_COMP1_NegativeTest4() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedRelString(
         "select p_name from tpch.part where p_size < 500 AND p_retailprice > 30.0",
         info,
@@ -394,7 +396,7 @@ public class SchemaTest {
   }
 
   @Test
-  public void testViewPART_COMP1_NegativeTest5() throws QuarkException {
+  public void testViewPART_COMP1_NegativeTest5() throws QuarkException, SQLException {
     QuarkTestUtil.checkParsedRelString(
         "select p_name from tpch.part where (p_size < 500 AND p_retailprice > 30.0 AND p_name = 'qubole') ",
         info,

--- a/optimizer/src/test/java/com/qubole/quark/planner/test/utilities/QuarkTestUtil.java
+++ b/optimizer/src/test/java/com/qubole/quark/planner/test/utilities/QuarkTestUtil.java
@@ -27,6 +27,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 
+import java.sql.SQLException;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -50,13 +51,14 @@ public class QuarkTestUtil {
     return mapper.writeValueAsString(defaultSchema);
   }
 
-  public static String getParsedSql(String sql, Properties info) throws QuarkException {
+  public static String getParsedSql(String sql, Properties info)
+      throws QuarkException, SQLException {
     Parser parser = new Parser(info);
     return parser.parse(sql).getParsedSql();
   }
 
   public static void checkParsedSql(String sql, Properties info, String expectedSql)
-      throws QuarkException {
+      throws QuarkException, SQLException {
     String finalQuery = getParsedSql(sql, info);
     assertEquals(expectedSql, finalQuery);
   }
@@ -75,7 +77,7 @@ public class QuarkTestUtil {
                                           Properties info,
                                           ImmutableList<String> expected,
                                           ImmutableList<String> unexpected)
-      throws QuarkException {
+      throws QuarkException, SQLException {
     Parser parser = new Parser(info);
     RelNode relNode = parser.parse(sql).getRelNode();
     String relStr = RelOptUtil.toString(relNode);

--- a/pom.xml
+++ b/pom.xml
@@ -217,8 +217,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <jackson.asl.version>1.9.13</jackson.asl.version>
         <jackson.version>2.4.0</jackson.version>
         <calcite.version>1.5.0-qds-r8</calcite.version>
+        <assertj.version>3.3.0</assertj.version>
         <!-- check if there is a better way -->
         <project.rootdir>${basedir}</project.rootdir>
 
@@ -132,7 +133,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>1.7.1</version>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -216,8 +217,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <jackson.asl.version>1.9.13</jackson.asl.version>
         <jackson.version>2.4.0</jackson.version>
         <calcite.version>1.5.0-qds-r8</calcite.version>
-        <assertj.version>3.3.0</assertj.version>
+        <assertj.version>2.3.0</assertj.version>
         <!-- check if there is a better way -->
         <project.rootdir>${basedir}</project.rootdir>
 


### PR DESCRIPTION
Fixes #10 
The important changes are in Parser. Then there are a couple of tests in QueryTest and ErrorsIntegTest. Rest of the changes are required because the API changed. I also tested with sqlline. O/P below:


```
0: jdbc:quark:model.json> sel;
Jan 28, 2016 4:23:20 PM org.apache.calcite.runtime.CalciteException <init>
SEVERE: org.apache.calcite.runtime.CalciteException: Non-query expression encountered in illegal context
Jan 28, 2016 4:23:20 PM org.apache.calcite.runtime.CalciteException <init>
SEVERE: org.apache.calcite.runtime.CalciteContextException: From line 1, column 1 to line 1, column 3: Non-query expression encountered in illegal context
Error: Error while executing SQL "sel": Non-query expression encountered in illegal context (state=,code=0)
0: jdbc:quark:model.json> select max(ss_promo_sk), ss_customer_sk from qhive.tpcds_orc_500.store_sales where ss_sold_date_sk >= 2452640 and ss_customer_sk > 3 and ss_customer_sk < 20 group ss_customer_sk;
Error: Error while executing SQL "select max(ss_promo_sk), ss_customer_sk from qhive.tpcds_orc_500.store_sales where ss_sold_date_sk >= 2452640 and ss_customer_sk > 3 and ss_customer_sk < 20 group ss_customer_sk": Encountered "group ss_customer_sk" at line 1, column 158.
Was expecting one of:
    <EOF>
    "ORDER" ...
```
