### PR TITLE
fix: usr: #38: Quark DB Catalog should accept dbCredentials as a JSON object

### DIFF
--- a/fatjdbc/src/main/java/com/qubole/quark/fatjdbc/utility/CatalogDetail.java
+++ b/fatjdbc/src/main/java/com/qubole/quark/fatjdbc/utility/CatalogDetail.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2015. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.qubole.quark.fatjdbc.utility;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Created by adeshr on 3/2/16.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CatalogDetail {
+  public final DbCredentials dbCredentials;
+
+  @JsonCreator
+  public CatalogDetail(@JsonProperty("dbCredentials") DbCredentials dbCredentials) {
+    this.dbCredentials = dbCredentials;
+  }
+
+  /**
+   * Store database credentials
+   */
+  private static class DbCredentials {
+    public final String url;
+    public final String username;
+    public final String password;
+    public final String encryptionKey;
+
+    @JsonCreator
+    DbCredentials(@JsonProperty("url") String url,
+                         @JsonProperty("username") String username,
+                         @JsonProperty("password") String password,
+                         @JsonProperty("encrypt_key") String encrpytionKey) {
+      this.url = url;
+      this.username = username;
+      this.password = password;
+      this.encryptionKey = encrpytionKey;
+    }
+  }
+}

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/ConnectionTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/ConnectionTest.java
@@ -60,7 +60,7 @@ public class ConnectionTest {
         testName + ".json");
     java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat" + resPath.toString(), props);
+        DriverManager.getConnection("jdbc:quark:fat:" + resPath.toString(), props);
 
     Statement statement = connection.createStatement();
     ResultSet rows =

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLMetaDataTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLMetaDataTest.java
@@ -106,7 +106,7 @@ public class DDLMetaDataTest {
     String sql = "CREATE DATASOURCE (name, type, url, ds_set_id, username, datasource_type)" +
         " values(\"H2_new\", \"H2\", \"" + inputUrl + "\", 1, \"sa\", \"JDBC\")";
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat", props);
+        DriverManager.getConnection("jdbc:quark:fat:", props);
     List<String> catalogList1 = new ArrayList<>();
     List<String> schemaList1 = new ArrayList<>();
     getSchema(connection, catalogList1, schemaList1);
@@ -131,7 +131,7 @@ public class DDLMetaDataTest {
     String sql = "CREATE DATASOURCE (name, type, url, ds_set_id, username, datasource_type)" +
         " values(\"H2_new\", \"H2\", \"" + inputUrl + "\", \"1\", \"sa\", \"JDBC\")";
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat", props);
+        DriverManager.getConnection("jdbc:quark:fat:", props);
     List<String> catalogList1 = new ArrayList<>();
     List<String> schemaList1 = new ArrayList<>();
     getSchema(connection, catalogList1, schemaList1);
@@ -155,7 +155,7 @@ public class DDLMetaDataTest {
   public void testAlterJdBc() throws SQLException {
     String sql = "ALTER DATASOURCE SET name = \"H2_test\" where id = 1";
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat", props);
+        DriverManager.getConnection("jdbc:quark:fat:", props);
     connection.createStatement().executeUpdate(sql);
     List<String> catalogList = new ArrayList<>();
     List<String> schemaList = new ArrayList<>();
@@ -171,7 +171,7 @@ public class DDLMetaDataTest {
     String sql1 = "CREATE DATASOURCE (name, type, url, ds_set_id, username, datasource_type)" +
         " values(\"H2_2\", \"H2\", \"" + inputUrl + "\", 1, \"sa\", \"JDBC\")";
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat", props);
+        DriverManager.getConnection("jdbc:quark:fat:", props);
     List<String> catalogList1 = new ArrayList<>();
     List<String> schemaList1 = new ArrayList<>();
     getSchema(connection, catalogList1, schemaList1);
@@ -204,7 +204,7 @@ public class DDLMetaDataTest {
   public void testAlterJdBcWrongParam() throws SQLException {
     String sql = "ALTER DATASOURCE SET name = \"H2_test\" where name = 'H2'";
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat", props);
+        DriverManager.getConnection("jdbc:quark:fat:", props);
     connection.createStatement().executeUpdate(sql);
     List<String> catalogList = new ArrayList<>();
     List<String> schemaList = new ArrayList<>();
@@ -219,7 +219,7 @@ public class DDLMetaDataTest {
   public void testAlterNonExistentSource() throws SQLException {
     String sql = "ALTER DATASOURCE SET name = \"H2_NonExist\" where id = 10";
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat", props);
+        DriverManager.getConnection("jdbc:quark:fat:", props);
     connection.createStatement().executeUpdate(sql);
     List<String> catalogList = new ArrayList<>();
     List<String> schemaList = new ArrayList<>();
@@ -231,7 +231,7 @@ public class DDLMetaDataTest {
   @Test
   public void testDropNonExistentJdbc() throws SQLException {
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat", props);
+        DriverManager.getConnection("jdbc:quark:fat:", props);
     List<String> catalogList1 = new ArrayList<>();
     List<String> schemaList1 = new ArrayList<>();
     getSchema(connection, catalogList1, schemaList1);

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/dbintegration/HiveTestIT.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/dbintegration/HiveTestIT.java
@@ -19,7 +19,7 @@ public class HiveTestIT {
   private static Connection getConnection() {
     try {
       Class.forName("com.qubole.quark.fatjdbc.QuarkDriver");
-      return DriverManager.getConnection("jdbc:quark:fat"
+      return DriverManager.getConnection("jdbc:quark:fat:"
           + System.getProperty("integrationTestResource") + "/hiveModel.json",
           new Properties());
     } catch (SQLException | ClassNotFoundException e) {

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/dbintegration/MySqlTestIT.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/dbintegration/MySqlTestIT.java
@@ -16,7 +16,7 @@ public class MySqlTestIT {
   private static Connection getConnection() {
     try {
       Class.forName("com.qubole.quark.fatjdbc.QuarkDriver");
-      return DriverManager.getConnection("jdbc:quark:fat"
+      return DriverManager.getConnection("jdbc:quark:fat:"
               + System.getProperty("integrationTestResource") + "/mySqlModel.json",
           new Properties());
     } catch (SQLException | ClassNotFoundException e) {

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/dbintegration/OracleTestIT.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/dbintegration/OracleTestIT.java
@@ -20,7 +20,7 @@ public class OracleTestIT {
   private static Connection getConnection() {
     try {
       Class.forName("com.qubole.quark.fatjdbc.QuarkDriver");
-      return DriverManager.getConnection("jdbc:quark:fat"
+      return DriverManager.getConnection("jdbc:quark:fat:"
           + System.getProperty("integrationTestResource") + "/oracleModel.json",
           new Properties());
     } catch (SQLException | ClassNotFoundException e) {

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/dbintegration/RedshiftTestIT.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/dbintegration/RedshiftTestIT.java
@@ -18,7 +18,7 @@ public class RedshiftTestIT {
   private static Connection getConnection() {
     try {
       Class.forName("com.qubole.quark.fatjdbc.QuarkDriver");
-      return DriverManager.getConnection("jdbc:quark:fat"
+      return DriverManager.getConnection("jdbc:quark:fat:"
           + System.getProperty("integrationTestResource") + "/redshiftModel.json",
           new Properties());
     } catch (SQLException | ClassNotFoundException e) {

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/integration/ErrorsIntegTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/integration/ErrorsIntegTest.java
@@ -33,7 +33,7 @@ public class ErrorsIntegTest extends IntegTest {
     setupTables(viewUrl, "tpcds_views.sql");
 
     Class.forName("com.qubole.quark.fatjdbc.QuarkDriver");
-    conn = DriverManager.getConnection("jdbc:quark:fat"
+    conn = DriverManager.getConnection("jdbc:quark:fat:"
         + TpcdsIntegTest.class.getResource("/ErrorsModel.json").getPath(), new Properties());
   }
 

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/integration/SimpleIntegTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/integration/SimpleIntegTest.java
@@ -43,7 +43,7 @@ public class SimpleIntegTest extends IntegTest {
     setupTables(viewUrl, "tpcds_views.sql");
 
     Class.forName("com.qubole.quark.fatjdbc.QuarkDriver");
-    conn = DriverManager.getConnection("jdbc:quark:fat"
+    conn = DriverManager.getConnection("jdbc:quark:fat:"
         + TpcdsIntegTest.class.getResource("/SimpleModel.json").getPath(), new Properties());
   }
 

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/integration/TpcdsIntegTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/integration/TpcdsIntegTest.java
@@ -51,7 +51,7 @@ public class TpcdsIntegTest extends IntegTest {
     setupTables(viewUrl, "tpcds_views.sql");
 
     Class.forName("com.qubole.quark.fatjdbc.QuarkDriver");
-    conn = DriverManager.getConnection("jdbc:quark:fat"
+    conn = DriverManager.getConnection("jdbc:quark:fat:"
         + TpcdsIntegTest.class.getResource("/TpcdsModel.json").getPath(), new Properties());
   }
 

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/utility/MetaDataTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/utility/MetaDataTest.java
@@ -83,7 +83,7 @@ public abstract class MetaDataTest {
   @Test
   public void testGetCatalogs() throws SQLException {
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat", props);
+        DriverManager.getConnection("jdbc:quark:fat:", props);
 
     ResultSet catalogs =
         connection.getMetaData().getCatalogs();
@@ -105,7 +105,7 @@ public abstract class MetaDataTest {
   @Test
   public void testGetSchemas() throws SQLException {
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat", props);
+        DriverManager.getConnection("jdbc:quark:fat:", props);
 
     ResultSet schemas =
         connection.getMetaData().getSchemas();
@@ -130,7 +130,7 @@ public abstract class MetaDataTest {
   @Test
   public void testGetTables() throws SQLException {
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat", props);
+        DriverManager.getConnection("jdbc:quark:fat:", props);
 
     ResultSet tables =
         connection.getMetaData().getTables(null, null, null, null);
@@ -151,7 +151,7 @@ public abstract class MetaDataTest {
   @Test
   public void testSearchTable() throws SQLException {
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat", props);
+        DriverManager.getConnection("jdbc:quark:fat:", props);
 
     ResultSet tables =
         connection.getMetaData().getTables(null, null, "SIMPLE", null);
@@ -172,7 +172,7 @@ public abstract class MetaDataTest {
   @Test
   public void testGetColumns() throws SQLException {
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat", props);
+        DriverManager.getConnection("jdbc:quark:fat:", props);
 
     ResultSet columns =
         connection.getMetaData().getColumns(null, "PUBLIC", "SIMPLE", null);

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/utility/SelectTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/utility/SelectTest.java
@@ -72,7 +72,7 @@ public abstract class SelectTest {
   public void testSimpleSelect() throws SQLException, ClassNotFoundException {
     Class.forName("com.qubole.quark.fatjdbc.QuarkDriver");
     Connection connection =
-        DriverManager.getConnection("jdbc:quark:fat", props);
+        DriverManager.getConnection("jdbc:quark:fat:", props);
 
     Statement statement = connection.createStatement();
     ResultSet rows =

--- a/server/src/main/java/com/qubole/quark/server/Main.java
+++ b/server/src/main/java/com/qubole/quark/server/Main.java
@@ -90,8 +90,8 @@ public final class Main implements Runnable {
       Meta meta = factory.create(Arrays.asList(args));
 
       int port = 8765;
-      if (QuarkMetaFactoryImpl.catalogDetail.port != 0) {
-        port = QuarkMetaFactoryImpl.catalogDetail.port;
+      if (QuarkMetaFactoryImpl.serverConfig.port != 0) {
+        port = QuarkMetaFactoryImpl.serverConfig.port;
       }
       LOG.debug("Listening on port " + port);
 

--- a/server/src/main/java/com/qubole/quark/server/QuarkMetaFactoryImpl.java
+++ b/server/src/main/java/com/qubole/quark/server/QuarkMetaFactoryImpl.java
@@ -38,7 +38,7 @@ import java.util.Properties;
  */
 public class QuarkMetaFactoryImpl implements Meta.Factory {
   protected static final Log LOG = LogFactory.getLog(Main.class);
-  public static CatalogDetail catalogDetail;
+  public static ServerConfig serverConfig;
   // invoked via reflection
   public QuarkMetaFactoryImpl() {
     super();
@@ -46,26 +46,20 @@ public class QuarkMetaFactoryImpl implements Meta.Factory {
 
   @Override
   public Meta create(List<String> args) {
-    Properties props = new Properties();
-    String url = "jdbc:quark:fat";
+    String url = "jdbc:quark:fat:";
+
     try {
       if (args.size() == 1) {
         String filePath = args.get(0);
         ObjectMapper objectMapper = new ObjectMapper();
-        catalogDetail = objectMapper.readValue(new File(filePath), CatalogDetail.class);
+        serverConfig = objectMapper.readValue(new File(filePath), ServerConfig.class);
 
-        // If dbCredentials are not present, than json Catalog is present in file
-        if (catalogDetail.dbCredentials == null) {
-          url = url + filePath;
-        } else if (catalogDetail.dbCredentials != null) {
-          props.put("dbCredentials", catalogDetail.dbCredentials);
-        }
-
+        url = url + filePath;
       } else {
         throw new RuntimeException(
             "1 argument expected. Received " + Arrays.toString(args.toArray()));
       }
-      return new JdbcMeta(url, props);
+      return new JdbcMeta(url, new Properties());
     } catch (SQLException | IOException e) {
       throw new RuntimeException(e);
     }

--- a/server/src/main/java/com/qubole/quark/server/ServerConfig.java
+++ b/server/src/main/java/com/qubole/quark/server/ServerConfig.java
@@ -20,17 +20,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Created by adeshr on 3/2/16.
+ * POJO for server specific configurations.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class CatalogDetail {
-  public final String dbCredentials;
+public class ServerConfig {
   public final int port;
 
   @JsonCreator
-  public CatalogDetail(@JsonProperty("dbCredentials") String dbCredentials,
-                       @JsonProperty("port") int port) {
-    this.dbCredentials = dbCredentials;
+  public ServerConfig(@JsonProperty("port") int port) {
     this.port = port;
   }
 }

--- a/server/src/test/resources/dbCatalog.json
+++ b/server/src/test/resources/dbCatalog.json
@@ -1,4 +1,9 @@
 {
-  "dbCredentials" : "{\"url\" : \"jdbc:h2:mem:DbTpcds;DB_CLOSE_DELAY=-1\", \"username\" : \"sa\", \"password\" : \"\", \"encrypt_key\" : \"key\" }",
+  "dbCredentials" : {
+    "url" : "jdbc:h2:mem:DbTpcds;DB_CLOSE_DELAY=-1",
+    "username" : "sa",
+    "password" : "",
+    "encrypt_key" : "key"
+  },
   "schemaFactory" : "com.qubole.quark.catalog.db.SchemaFactory"
 }


### PR DESCRIPTION
Instead of serialized json string, now Quark will accept json object for dbCredentials.  
Also, fixed the connect-string for fat-jdbc (added `:` after `jdbc:quark:fat`).