### PR TITLE
chg:dev:#53 Remove dependency on jackson-guava

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -40,11 +40,6 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-guava</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.10</version>

--- a/catalog/src/main/java/com/qubole/quark/catalog/json/RootSchema.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/json/RootSchema.java
@@ -18,15 +18,14 @@ package com.qubole.quark.catalog.json;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import com.google.common.collect.ImmutableList;
-
+import java.util.Arrays;
 import java.util.List;
 
 /**
  * Describes the root element in the JSON template.
  */
 public class RootSchema {
-  public final List<String> supportedVersions = ImmutableList.of("2.0");
+  public final List<String> supportedVersions = Arrays.asList("2.0");
   public final List<DataSourceSchema> dataSources;
   public final Integer defaultDataSource;
   public final RelSchema relSchema;

--- a/catalog/src/main/java/com/qubole/quark/catalog/json/SchemaFactory.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/json/SchemaFactory.java
@@ -16,7 +16,6 @@
 package com.qubole.quark.catalog.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.common.collect.ImmutableList;
 
 import com.qubole.quark.QuarkException;
@@ -64,7 +63,6 @@ public class SchemaFactory implements QuarkFactory {
   public QuarkFactoryResult create(Properties info) throws QuarkException {
     try {
       ObjectMapper objectMapper = new ObjectMapper();
-      objectMapper.registerModule(new GuavaModule());
       RootSchema rootSchema = objectMapper.readValue((String) info.get("model"), RootSchema.class);
 
       ImmutableList.Builder<DataSourceSchema> schemaList = new ImmutableList.Builder<>();

--- a/catalog/src/test/java/com/qubole/quark/catalog/json/schema/RootSchemaTest.java
+++ b/catalog/src/test/java/com/qubole/quark/catalog/json/schema/RootSchemaTest.java
@@ -16,7 +16,6 @@
 package com.qubole.quark.catalog.json.schema;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.qubole.quark.catalog.json.RootSchema;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -54,7 +53,6 @@ public class RootSchemaTest {
 
 
     ObjectMapper objectMapper = new ObjectMapper();
-    objectMapper.registerModule(new GuavaModule());
     RootSchema rootSchema = objectMapper.readValue(jsonTestString, RootSchema.class);
 
     assertThat(rootSchema.dataSources.size()).isEqualTo(1);
@@ -79,7 +77,6 @@ public class RootSchemaTest {
             "  }" +
             "}";
     ObjectMapper objectMapper = new ObjectMapper();
-    objectMapper.registerModule(new GuavaModule());
     RootSchema rootSchema = objectMapper.readValue(jsonTestString, RootSchema.class);
 
     assertThat(rootSchema.relSchema.getViews().size()).isEqualTo(1);

--- a/fatjdbc/pom.xml
+++ b/fatjdbc/pom.xml
@@ -45,11 +45,6 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-guava</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>

--- a/optimizer/src/main/java/com/qubole/quark/planner/QuarkCube.java
+++ b/optimizer/src/main/java/com/qubole/quark/planner/QuarkCube.java
@@ -306,29 +306,29 @@ public class QuarkCube {
    */
   public final Object sql;
   public final List<Measure> measures;
-  public final ImmutableSet<Dimension> dimensions;
-  public final ImmutableList<String> tableName;
-  public final ImmutableList<String> alias;
+  public final Set<Dimension> dimensions;
+  public final List<String> tableName;
+  public final List<String> alias;
   public final String groupingColumn;
   public final Set<Set<Dimension>> groups;
 
   public QuarkCube(String name, Object sql, List<Measure> measures,
-                   ImmutableList<Dimension> dimensionList,
+                   List<Dimension> dimensionList,
                    List<String> tableName, String groupingColumn) {
     this(name, sql, measures, dimensionList, ImmutableList.<Group>of(),
         tableName, groupingColumn, tableName);
   }
 
   public QuarkCube(String name, Object sql, List<Measure> measures,
-                   ImmutableList<Dimension> dimensionList,
-                   ImmutableList<Group> groupList,
+                   List<Dimension> dimensionList,
+                   List<Group> groupList,
                    List<String> tableName, String groupingColumn) {
     this(name, sql, measures, dimensionList, groupList, tableName, groupingColumn, tableName);
   }
 
   public QuarkCube(String name, Object sql, List<Measure> measures,
-                   ImmutableList<Dimension> dimensionList,
-                   ImmutableList<Group> groupList,
+                   List<Dimension> dimensionList,
+                   List<Group> groupList,
                    List<String> tableName, String groupingColumn,
                    List<String> alias) {
     this.name = name;
@@ -347,12 +347,12 @@ public class QuarkCube {
         Ordering.natural().immutableSortedCopy(idToDimensionMap.values()));
   }
 
-  private void buildGroups(ImmutableList<Dimension> dimensions,
-                           ImmutableList<Group> groupList,
+  private void buildGroups(List<Dimension> dimensions,
+                           List<Group> groupList,
                            Map<String, Set<Dimension>> groupToDimensionMap,
                            Map<String, Dimension> idToDimensionMap) {
 
-    ImmutableList<Dimension> dimToBeAdded = dimensions;
+    List<Dimension> dimToBeAdded = dimensions;
     //code below makes sure that for heirarichal dimension,
     // parent dimension is created before child
     while (!dimToBeAdded.isEmpty()) {
@@ -375,7 +375,7 @@ public class QuarkCube {
   }
 
   private void addDimension(Map<String, Set<QuarkCube.Dimension>> groupToDimensionMap,
-                            ImmutableList<Group> groupList,
+                            List<Group> groupList,
                             Map<String, QuarkCube.Dimension> idToDimensionMap,
                             Dimension dimension) {
     Dimension parentDimension = null;
@@ -477,7 +477,7 @@ public class QuarkCube {
     return builder.build();
   }
 
-  public static Set<Set<Dimension>> getDimensionSets(ImmutableSet<Dimension> dimensions) {
+  public static Set<Set<Dimension>> getDimensionSets(Set<Dimension> dimensions) {
     Set<Set<Dimension>> result = Sets.newHashSet();
     result.add(new HashSet<Dimension>());
     for (Dimension d : dimensions) {


### PR DESCRIPTION
Jackson Guava is required to parse JSON into Immutable Collections. Its a
heavy-weight jar which causes problems with conflicting dependencies. If
we do not use Immutable Collections in function and class signatures, we
do not need to serialize/deserialize json. Also there is one less dependency.