### PR TITLE
new:dev:#70:Encryption of database fields is optional.Encryptor isn't a singleton

### DIFF
--- a/catalog/src/main/java/com/qubole/quark/catalog/db/dao/DataSourceDAO.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/dao/DataSourceDAO.java
@@ -15,7 +15,7 @@
 
 package com.qubole.quark.catalog.db.dao;
 
-import com.qubole.quark.catalog.db.encryption.MysqlAES;
+import com.qubole.quark.catalog.db.encryption.Encrypt;
 import com.qubole.quark.catalog.db.mapper.DataSourceMapper;
 import com.qubole.quark.catalog.db.pojo.DataSource;
 
@@ -56,18 +56,14 @@ public abstract class DataSourceDAO {
   public abstract void delete(@Bind("id") int id);
 
   public int insertJDBC(String name, String type, String url, long dsSetId,
-      String dataSourcetype, JdbcSourceDAO jdbcDao, String username, String password,
-      String key) {
-    if (key != null) {
-      try {
-        MysqlAES mysqlAES = MysqlAES.getInstance();
-        mysqlAES.setKey(key);
-        url = mysqlAES.convertToDatabaseColumn(url);
-        username = mysqlAES.convertToDatabaseColumn(username);
-        password = mysqlAES.convertToDatabaseColumn(password);
-      } catch (SQLException e) {
-        throw new RuntimeException(e);
-      }
+                        String dataSourcetype, JdbcSourceDAO jdbcDao, String username,
+                        String password, Encrypt encrypt) {
+    try {
+      url = encrypt.convertToDatabaseColumn(url);
+      username = encrypt.convertToDatabaseColumn(username);
+      password = encrypt.convertToDatabaseColumn(password);
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
     }
     int id = insert(name, type, url, dsSetId, dataSourcetype);
     jdbcDao.insert(id, username, password);
@@ -77,16 +73,12 @@ public abstract class DataSourceDAO {
   @Transaction
   public int insertQuboleDB(String name, String type, String url, long dsSetId,
       String dataSourcetype, QuboleDbSourceDAO quboleDao, int dbTapId, String authToken,
-      String key) {
-    if (key != null) {
-      try {
-        MysqlAES mysqlAES = MysqlAES.getInstance();
-        mysqlAES.setKey(key);
-        url = mysqlAES.convertToDatabaseColumn(url);
-        authToken = mysqlAES.convertToDatabaseColumn(authToken);
-      } catch (SQLException e) {
-        throw new RuntimeException(e);
-      }
+      Encrypt encrypt) {
+    try {
+      url = encrypt.convertToDatabaseColumn(url);
+      authToken = encrypt.convertToDatabaseColumn(authToken);
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
     }
     int id = insert(name, type, url, dsSetId, dataSourcetype);
     quboleDao.insert(id, dbTapId, authToken);

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/dao/JdbcSourceDAO.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/dao/JdbcSourceDAO.java
@@ -15,7 +15,7 @@
 
 package com.qubole.quark.catalog.db.dao;
 
-import com.qubole.quark.catalog.db.encryption.MysqlAES;
+import com.qubole.quark.catalog.db.encryption.Encrypt;
 import com.qubole.quark.catalog.db.mapper.JdbcSourceMapper;
 import com.qubole.quark.catalog.db.pojo.JdbcSource;
 
@@ -58,17 +58,13 @@ public abstract class JdbcSourceDAO {
   public abstract void delete(@Bind("id") int id);
 
   @Transaction
-  public int update(JdbcSource source, DataSourceDAO dao, String key) {
-    if (key != null) {
-      try {
-        MysqlAES mysqlAES = MysqlAES.getInstance();
-        mysqlAES.setKey(key);
-        source.setUrl(mysqlAES.convertToDatabaseColumn(source.getUrl()));
-        source.setUsername(mysqlAES.convertToDatabaseColumn(source.getUsername()));
-        source.setPassword(mysqlAES.convertToDatabaseColumn(source.getPassword()));
-      } catch (SQLException e) {
-        throw new RuntimeException(e);
-      }
+  public int update(JdbcSource source, DataSourceDAO dao, Encrypt encrypt) {
+    try {
+      source.setUrl(encrypt.convertToDatabaseColumn(source.getUrl()));
+      source.setUsername(encrypt.convertToDatabaseColumn(source.getUsername()));
+      source.setPassword(encrypt.convertToDatabaseColumn(source.getPassword()));
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
     }
     updateJdbc(source);
     return dao.update(source);

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/dao/QuboleDbSourceDAO.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/dao/QuboleDbSourceDAO.java
@@ -15,7 +15,7 @@
 
 package com.qubole.quark.catalog.db.dao;
 
-import com.qubole.quark.catalog.db.encryption.MysqlAES;
+import com.qubole.quark.catalog.db.encryption.Encrypt;
 import com.qubole.quark.catalog.db.mapper.QuboleDbSourceMapper;
 import com.qubole.quark.catalog.db.pojo.QuboleDbSource;
 
@@ -59,16 +59,12 @@ public abstract class QuboleDbSourceDAO {
   public abstract void delete(@Bind("id") int id);
 
   @Transaction
-  public int update(QuboleDbSource db, DataSourceDAO dao, String key) {
-    if (key != null) {
-      try {
-        MysqlAES mysqlAES = MysqlAES.getInstance();
-        mysqlAES.setKey(key);
-        db.setUrl(mysqlAES.convertToDatabaseColumn(db.getUrl()));
-        db.setAuthToken(mysqlAES.convertToDatabaseColumn(db.getAuthToken()));
-      } catch (SQLException e) {
-        throw new RuntimeException(e);
-      }
+  public int update(QuboleDbSource db, DataSourceDAO dao, Encrypt encrypt) {
+    try {
+      db.setUrl(encrypt.convertToDatabaseColumn(db.getUrl()));
+      db.setAuthToken(encrypt.convertToDatabaseColumn(db.getAuthToken()));
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
     }
     updateQubole(db);
     return dao.update(db);

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/encryption/AESEncrypt.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/encryption/AESEncrypt.java
@@ -26,20 +26,10 @@ import javax.crypto.spec.SecretKeySpec;
 /**
  * Encrypt/decrypt data for/from db using Mysql AES algorithm.
  */
-public class MysqlAES {
-  private String key;
-  private static MysqlAES mysqlAES;
+public class AESEncrypt implements Encrypt {
+  private final String key;
 
-  private MysqlAES() {}
-
-  public static MysqlAES getInstance() {
-    if (mysqlAES == null) {
-      mysqlAES = new MysqlAES();
-    }
-    return mysqlAES;
-  }
-
-  public void setKey(String key) {
+  public AESEncrypt(String key) {
     this.key = key;
   }
 
@@ -79,7 +69,5 @@ public class MysqlAES {
     } catch (Exception e) {
       throw new SQLException(e);
     }
-
   }
-
 }

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/encryption/Encrypt.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/encryption/Encrypt.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2015. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.qubole.quark.catalog.db.encryption;
+
+import java.sql.SQLException;
+
+/**
+ * Created by qubole on 4/25/16.
+ */
+public interface Encrypt {
+  String convertToDatabaseColumn(String phrase) throws SQLException;
+  String convertToEntityAttribute(String phrase) throws SQLException;
+}

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/encryption/NoopEncrypt.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/encryption/NoopEncrypt.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.qubole.quark.catalog.db.encryption;
+
+import java.sql.SQLException;
+
+/**
+ * Created by rajatv on 4/25/16.
+ */
+public class NoopEncrypt implements Encrypt {
+  public String convertToDatabaseColumn(String phrase) throws SQLException {
+    return phrase;
+  }
+
+  public String convertToEntityAttribute(String phrase) throws SQLException {
+    return phrase;
+  }
+}

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/mapper/JdbcSourceMapper.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/mapper/JdbcSourceMapper.java
@@ -15,7 +15,7 @@
 
 package com.qubole.quark.catalog.db.mapper;
 
-import com.qubole.quark.catalog.db.encryption.MysqlAES;
+import com.qubole.quark.catalog.db.encryption.Encrypt;
 import com.qubole.quark.catalog.db.pojo.JdbcSource;
 
 import org.skife.jdbi.v2.StatementContext;
@@ -29,11 +29,10 @@ import java.sql.SQLException;
  */
 public class JdbcSourceMapper implements ResultSetMapper<JdbcSource> {
   public JdbcSource map(int index, ResultSet r, StatementContext ctx) throws SQLException {
-    MysqlAES mysqlAES = MysqlAES.getInstance();
-
+    Encrypt encrypt = (Encrypt) ctx.getAttribute("encryptClass");
     return new JdbcSource(r.getInt("id"), r.getString("type"), r.getString("name"),
-        r.getString("datasource_type"), mysqlAES.convertToEntityAttribute(r.getString("url")),
-        r.getInt("ds_set_id"), mysqlAES.convertToEntityAttribute(r.getString("username")),
-        mysqlAES.convertToEntityAttribute(r.getString("password")));
+        r.getString("datasource_type"), encrypt.convertToEntityAttribute(r.getString("url")),
+        r.getInt("ds_set_id"), encrypt.convertToEntityAttribute(r.getString("username")),
+        encrypt.convertToEntityAttribute(r.getString("password")));
   }
 }

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/mapper/QuboleDbSourceMapper.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/mapper/QuboleDbSourceMapper.java
@@ -15,7 +15,7 @@
 
 package com.qubole.quark.catalog.db.mapper;
 
-import com.qubole.quark.catalog.db.encryption.MysqlAES;
+import com.qubole.quark.catalog.db.encryption.Encrypt;
 import com.qubole.quark.catalog.db.pojo.QuboleDbSource;
 
 import org.skife.jdbi.v2.StatementContext;
@@ -29,11 +29,10 @@ import java.sql.SQLException;
  */
 public class QuboleDbSourceMapper implements ResultSetMapper<QuboleDbSource> {
   public QuboleDbSource map(int index, ResultSet r, StatementContext ctx) throws SQLException {
-    MysqlAES mysqlAES = MysqlAES.getInstance();
-
+    Encrypt encrypt = (Encrypt) ctx.getAttribute("encryptClass");
     return new QuboleDbSource(r.getInt("id"), r.getString("type"), r.getString("name"),
-        r.getString("datasource_type"), mysqlAES.convertToEntityAttribute(r.getString("url")),
+        r.getString("datasource_type"), encrypt.convertToEntityAttribute(r.getString("url")),
         r.getInt("ds_set_id"), r.getLong("dbtap_id"),
-        mysqlAES.convertToEntityAttribute(r.getString("auth_token")));
+        encrypt.convertToEntityAttribute(r.getString("auth_token")));
   }
 }

--- a/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/JdbcSourceTest.java
+++ b/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/JdbcSourceTest.java
@@ -16,7 +16,7 @@
 package com.qubole.quark.catalog.db.pojo;
 
 import com.qubole.quark.catalog.db.dao.JdbcSourceDAO;
-import com.qubole.quark.catalog.db.encryption.MysqlAES;
+import com.qubole.quark.catalog.db.encryption.AESEncrypt;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
@@ -42,11 +42,9 @@ public class JdbcSourceTest extends DbUtility {
 
     setUpDb(dbSchemaUrl, "sa", "", "tpcds.sql");
 
-    MysqlAES mysqlAES = MysqlAES.getInstance();
-    mysqlAES.setKey("easy");
-
     DBI dbi = new DBI(dbSchemaUrl, "sa", "");
     jdbcSourceDAO = dbi.onDemand(JdbcSourceDAO.class);
+    dbi.define("encryptClass", new AESEncrypt("easy"));
   }
 
   @Test

--- a/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/QuboleDbSourceTest.java
+++ b/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/QuboleDbSourceTest.java
@@ -16,7 +16,7 @@
 package com.qubole.quark.catalog.db.pojo;
 
 import com.qubole.quark.catalog.db.dao.QuboleDbSourceDAO;
-import com.qubole.quark.catalog.db.encryption.MysqlAES;
+import com.qubole.quark.catalog.db.encryption.AESEncrypt;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
@@ -42,11 +42,9 @@ public class QuboleDbSourceTest extends DbUtility {
 
     setUpDb(dbSchemaUrl, "sa", "", "tpcds.sql");
 
-    MysqlAES mysqlAES = MysqlAES.getInstance();
-    mysqlAES.setKey("easy");
-
     DBI dbi = new DBI(dbSchemaUrl, "sa", "");
     quboleDbSourceDAO = dbi.onDemand(QuboleDbSourceDAO.class);
+    dbi.define("encryptClass", new AESEncrypt("easy"));
   }
 
   @Test

--- a/fatjdbc/src/main/java/com/qubole/quark/fatjdbc/QuarkDriver.java
+++ b/fatjdbc/src/main/java/com/qubole/quark/fatjdbc/QuarkDriver.java
@@ -126,6 +126,7 @@ public class QuarkDriver extends UnregisteredDriver {
           info.setProperty("user", catalogDetail.dbCredentials.username);
           info.setProperty("password", catalogDetail.dbCredentials.password);
           info.setProperty("encryptionKey", catalogDetail.dbCredentials.encryptionKey);
+          info.setProperty("encrypt", catalogDetail.dbCredentials.encrypt);
         } catch (IOException e) {
           throw new SQLException(e);
         }

--- a/fatjdbc/src/main/java/com/qubole/quark/fatjdbc/utility/CatalogDetail.java
+++ b/fatjdbc/src/main/java/com/qubole/quark/fatjdbc/utility/CatalogDetail.java
@@ -39,16 +39,19 @@ public class CatalogDetail {
     public final String username;
     public final String password;
     public final String encryptionKey;
+    public final String encrypt;
 
     @JsonCreator
     DbCredentials(@JsonProperty("url") String url,
                          @JsonProperty("username") String username,
                          @JsonProperty("password") String password,
-                         @JsonProperty("encrypt_key") String encrpytionKey) {
+                         @JsonProperty("encrypt_key") String encrpytionKey,
+                         @JsonProperty("encrypt") String encrypt) {
       this.url = url;
       this.username = username;
       this.password = password;
       this.encryptionKey = encrpytionKey;
+      this.encrypt = encrypt;
     }
   }
 }

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLMetaDataTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLMetaDataTest.java
@@ -15,7 +15,7 @@
 
 package com.qubole.quark.fatjdbc.test;
 
-import com.qubole.quark.catalog.db.encryption.MysqlAES;
+import com.qubole.quark.catalog.db.encryption.AESEncrypt;
 import com.qubole.quark.fatjdbc.test.utility.MetaDataTest;
 import org.flywaydb.core.Flyway;
 import org.junit.BeforeClass;
@@ -61,13 +61,6 @@ public class DDLMetaDataTest {
     flyway.setDataSource(dbSchemaUrl, "sa", "");
     flyway.migrate();
 
-    // Encrypting url, username and password before storing in db
-    MysqlAES mysqlAES = MysqlAES.getInstance();
-    mysqlAES.setKey("xyz");
-    String url = mysqlAES.convertToDatabaseColumn(h2Url);
-    String username = mysqlAES.convertToDatabaseColumn("sa");
-    String password = mysqlAES.convertToDatabaseColumn("");
-
     Properties connInfo = new Properties();
     connInfo.setProperty("url", dbSchemaUrl);
     connInfo.setProperty("user", "sa");
@@ -77,8 +70,8 @@ public class DDLMetaDataTest {
 
     Statement stmt = dbConnection.createStatement();
     String sql = "insert into data_sources(name, type, url, ds_set_id, datasource_type) values "
-        + "('H2', 'H2', '" + url + "', 1, 'JDBC'); insert into jdbc_sources (id, "
-        + "username, password) values(1, '" + username + "', '" + password + "');"
+        + "('H2', 'H2', '" + h2Url + "', 1, 'JDBC'); insert into jdbc_sources (id, "
+        + "username, password) values(1, 'sa', '');"
         + "update ds_sets set default_datasource_id = 1 where id = 1;";
 
     stmt.execute(sql);

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLViewTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLViewTest.java
@@ -15,7 +15,7 @@
 
 package com.qubole.quark.fatjdbc.test;
 
-import com.qubole.quark.catalog.db.encryption.MysqlAES;
+import com.qubole.quark.catalog.db.encryption.AESEncrypt;
 import org.flywaydb.core.Flyway;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -97,13 +97,6 @@ public class DDLViewTest {
     flyway.setDataSource(dbSchemaUrl, "sa", "");
     flyway.migrate();
 
-    // Encrypting url, username and password before storing in db
-    MysqlAES mysqlAES = MysqlAES.getInstance();
-    mysqlAES.setKey("xyz");
-    String url = mysqlAES.convertToDatabaseColumn(tpcdsUrl);
-    String username = mysqlAES.convertToDatabaseColumn("sa");
-    String password = mysqlAES.convertToDatabaseColumn("");
-
     Properties connInfo = new Properties();
     connInfo.setProperty("url", dbSchemaUrl);
     connInfo.setProperty("user", "sa");
@@ -114,14 +107,13 @@ public class DDLViewTest {
     Statement stmt = dbConnection.createStatement();
     // Sql statement default data-source and view datasource
     String sql = "insert into data_sources(name, type, url, ds_set_id, datasource_type) values "
-        + "('CANONICAL', 'H2', '" + url + "', 1, 'JDBC'); insert into jdbc_sources (id, "
-        + "username, password) values(1, '" + username + "', '" + password + "');"
+        + "('CANONICAL', 'H2', '" + tpcdsUrl + "', 1, 'JDBC'); insert into jdbc_sources (id, "
+        + "username, password) values(1, 'sa', '');"
         + "update ds_sets set default_datasource_id = 1 where id = 1;";
 
     sql = sql + "insert into data_sources(name, type, url, ds_set_id, datasource_type) values "
-        + "('VIEWS', 'H2', '" + mysqlAES.convertToDatabaseColumn(tpcdsViewUrl) + "', 1, 'JDBC'); "
-        + "insert into jdbc_sources (id, username, password) values(2, '" + username + "', '"
-        + password + "');";
+        + "('VIEWS', 'H2', '" + tpcdsViewUrl + "', 1, 'JDBC'); "
+        + "insert into jdbc_sources (id, username, password) values(2, 'sa', '');";
 
     // Sql statement to add views, to be used for drop and alter view respectively.
     sql = sql + " insert into partitions(name, description, cost, query, ds_set_id, destination_id, "

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DbMetaDataTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DbMetaDataTest.java
@@ -15,7 +15,7 @@
 
 package com.qubole.quark.fatjdbc.test;
 
-import com.qubole.quark.catalog.db.encryption.MysqlAES;
+import com.qubole.quark.catalog.db.encryption.AESEncrypt;
 import com.qubole.quark.fatjdbc.test.utility.MetaDataTest;
 
 import org.flywaydb.core.Flyway;
@@ -52,13 +52,6 @@ public class DbMetaDataTest extends MetaDataTest {
     flyway.setDataSource(dbSchemaUrl, "sa", "");
     flyway.migrate();
 
-    // Encrypting url, username and password before storing in db
-    MysqlAES mysqlAES = MysqlAES.getInstance();
-    mysqlAES.setKey("easy");
-    String url = mysqlAES.convertToDatabaseColumn(h2Url);
-    String username = mysqlAES.convertToDatabaseColumn("sa");
-    String password = mysqlAES.convertToDatabaseColumn("");
-
     Properties connInfo = new Properties();
     connInfo.setProperty("url", dbSchemaUrl);
     connInfo.setProperty("user", "sa");
@@ -68,8 +61,8 @@ public class DbMetaDataTest extends MetaDataTest {
 
     Statement stmt = dbConnection.createStatement();
     String sql = "insert into data_sources(name, type, url, ds_set_id, datasource_type) values "
-        + "('H2', 'H2', '" + url + "', 1, 'JDBC'); insert into jdbc_sources (id, "
-        + "username, password) values(1, '" + username + "', '" + password + "');" +
+        + "('H2', 'H2', '" + h2Url + "', 1, 'JDBC'); insert into jdbc_sources (id, "
+        + "username, password) values(1, 'sa', '');" +
         "update ds_sets set default_datasource_id = 1 where id = 1;";
 
     stmt.execute(sql);

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DbSelectTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DbSelectTest.java
@@ -15,7 +15,7 @@
 
 package com.qubole.quark.fatjdbc.test;
 
-import com.qubole.quark.catalog.db.encryption.MysqlAES;
+import com.qubole.quark.catalog.db.encryption.AESEncrypt;
 import com.qubole.quark.fatjdbc.test.utility.SelectTest;
 import org.flywaydb.core.Flyway;
 import org.junit.BeforeClass;
@@ -47,13 +47,6 @@ public class DbSelectTest extends SelectTest {
     flyway.setDataSource(dbSchemaUrl, "sa", "");
     flyway.migrate();
 
-    // Encrypting url, username and password before storing in db
-    MysqlAES mysqlAES = MysqlAES.getInstance();
-    mysqlAES.setKey("easy");
-    String url = mysqlAES.convertToDatabaseColumn(dbUrl);
-    String username = mysqlAES.convertToDatabaseColumn("sa");
-    String password = mysqlAES.convertToDatabaseColumn("");
-
     Properties connInfo = new Properties();
     connInfo.setProperty("url", dbSchemaUrl);
     connInfo.setProperty("user", "sa");
@@ -63,8 +56,8 @@ public class DbSelectTest extends SelectTest {
 
     Statement stmt = dbConnection.createStatement();
     String sql = "insert into data_sources(name, type, url, ds_set_id, datasource_type) values "
-        + "('H2', 'H2', '" + url + "', 1, 'JDBC'); insert into jdbc_sources (id, "
-        + "username, password) values(1, '" + username + "', '" + password + "');" +
+        + "('H2', 'H2', '" + dbUrl + "', 1, 'JDBC'); insert into jdbc_sources (id, "
+        + "username, password) values(1, 'sa', '');" +
         "update ds_sets set default_datasource_id = 1 where id = 1;";
 
     stmt.execute(sql);

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/MaterializedViewJoinTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/MaterializedViewJoinTest.java
@@ -1,6 +1,6 @@
 package com.qubole.quark.fatjdbc.test;
 
-import com.qubole.quark.catalog.db.encryption.MysqlAES;
+import com.qubole.quark.catalog.db.encryption.AESEncrypt;
 import com.qubole.quark.planner.parser.SqlQueryParser;
 import com.qubole.quark.sql.ResultProcessor;
 import org.apache.calcite.sql.SqlDialect;
@@ -35,13 +35,6 @@ public class MaterializedViewJoinTest {
     flyway.setDataSource(dbSchemaUrl, "sa", "");
     flyway.migrate();
 
-    // Encrypting url, username and password before storing in db
-    MysqlAES mysqlAES = MysqlAES.getInstance();
-    mysqlAES.setKey("key");
-    String url = mysqlAES.convertToDatabaseColumn(dbUrl);
-    String username = mysqlAES.convertToDatabaseColumn("sa");
-    String password = mysqlAES.convertToDatabaseColumn("");
-
     connInfo = new Properties();
     connInfo.setProperty("url", dbSchemaUrl);
     connInfo.setProperty("user", "sa");
@@ -51,14 +44,14 @@ public class MaterializedViewJoinTest {
             getResource("/HiveUDFModel.json").getPath(), "");
     connInfo.setProperty("schemaFactory",
         "com.qubole.quark.catalog.db.SchemaFactory");
-    connInfo.setProperty("encryptionKey", "key");
+    connInfo.setProperty("encryption", "false");
 
     dbConnection = DriverManager.getConnection(dbSchemaUrl, connInfo);
 
     Statement stmt = dbConnection.createStatement();
     String sql = "insert into data_sources(name, type, url, ds_set_id, datasource_type) values "
-        + "('H2', 'H2', '" + url + "', 1, 'JDBC'); insert into jdbc_sources (id, "
-        + "username, password) values(1, '" + username + "', '" + password + "');"
+        + "('H2', 'H2', '" + dbUrl + "', 1, 'JDBC'); insert into jdbc_sources (id, "
+        + "username, password) values(1, 'sa', '');"
         + "update ds_sets set default_datasource_id = 1 where id = 1;"
         + "insert into partitions(`name`, `description`, `cost`, `query`, `ds_set_id`,"
         + " `destination_id`,`schema_name`, `table_name`)"

--- a/server/src/test/resources/dbCatalog.json
+++ b/server/src/test/resources/dbCatalog.json
@@ -3,7 +3,8 @@
     "url" : "jdbc:h2:mem:DbTpcds;DB_CLOSE_DELAY=-1",
     "username" : "sa",
     "password" : "",
-    "encrypt_key" : "key"
+    "encrypt_key" : "key",
+    "encrypt":"true"
   },
   "schemaFactory" : "com.qubole.quark.catalog.db.SchemaFactory"
 }

--- a/server/src/test/resources/migrationTest.json
+++ b/server/src/test/resources/migrationTest.json
@@ -3,7 +3,8 @@
     "url": "jdbc:h2:mem:MigrationTest;DB_CLOSE_DELAY=-1",
     "username": "sa",
     "password": "",
-    "encrypt_key": "key"
+    "encrypt_key": "key",
+    "encrypt":"true"
   },
   "port": 8800
 }


### PR DESCRIPTION
Accept a new field in credential -> "encrypt" to decide whether fields in the
DB catalog like url and password are encrypted or not.

MySQLAES was a singleton to allow passing of keys to JDBI mappers. The
problem with this approach is that its not possible to have multiple instances
of DB catalog in the same JVM. Use DBI::define to pass an Encrypt object instead.
This object is available in StatementContext argument of the map function in a
mapper.

Fix #70