### PR TITLE
fix:usr:#73 Add constraints to MaterializedViewFilterScanRule

### DIFF
--- a/optimizer/src/test/java/com/qubole/quark/planner/test/Tpcds.java
+++ b/optimizer/src/test/java/com/qubole/quark/planner/test/Tpcds.java
@@ -220,6 +220,37 @@ public class Tpcds extends TestSchema {
 
     builder.put("STORE_SALES", store_sales);
 
+    QuarkTable web_site = new QuarkTable(new ImmutableList.Builder<QuarkColumn>()
+        .add(new QuarkColumn("web_site_sk", Types.INTEGER))
+        .add(new QuarkColumn("web_site_id", Types.CHAR))
+        .add(new QuarkColumn("web_rec_start_date", Types.DATE))
+        .add(new QuarkColumn("web_rec_end_data", Types.DATE))
+        .add(new QuarkColumn("web_name", Types.VARCHAR))
+        .add(new QuarkColumn("web_open_date_sk", Types.INTEGER))
+            .add(new QuarkColumn("web_close_date_sk", Types.INTEGER))
+            .add(new QuarkColumn("web_class", Types.VARCHAR))
+            .add(new QuarkColumn("web_manager", Types.VARCHAR))
+            .add(new QuarkColumn("web_mkt_id", Types.INTEGER))
+            .add(new QuarkColumn("web_mkt_class", Types.VARCHAR))
+            .add(new QuarkColumn("web_mkt_desc", Types.VARCHAR))
+            .add(new QuarkColumn("web_market_manager", Types.VARCHAR))
+            .add(new QuarkColumn("web_company_id", Types.INTEGER))
+            .add(new QuarkColumn("web_company_name", Types.CHAR))
+            .add(new QuarkColumn("web_street_number", Types.CHAR))
+            .add(new QuarkColumn("web_street_name", Types.VARCHAR))
+            .add(new QuarkColumn("web_street_type", Types.CHAR))
+            .add(new QuarkColumn("web_suite_number", Types.CHAR))
+            .add(new QuarkColumn("web_city", Types.VARCHAR))
+            .add(new QuarkColumn("web_county", Types.VARCHAR))
+            .add(new QuarkColumn("web_state", Types.CHAR))
+            .add(new QuarkColumn("web_zip", Types.CHAR))
+            .add(new QuarkColumn("web_country", Types.VARCHAR))
+            .add(new QuarkColumn("web_gmt_offset", Types.DECIMAL))
+            .add(new QuarkColumn("web_tax_percentage", Types.DECIMAL)).build()
+    );
+
+    builder.put("WEB_SITE", web_site);
+
     QuarkTable store_sales_cube = new QuarkTable(new ImmutableList.Builder<QuarkColumn>()
         .add(new QuarkColumn("i_item_id", Types.VARCHAR))
         .add(new QuarkColumn("c_customer_id", Types.VARCHAR))
@@ -288,6 +319,14 @@ public class Tpcds extends TestSchema {
 
     builder.put("STORE_SALES_CUBE_MONTHLY", store_sales_cube_monthly);
 
+    QuarkTable web_site_partition = new QuarkTable(new ImmutableList.Builder<QuarkColumn>()
+            .add(new QuarkColumn("web_site_sk", Types.INTEGER))
+            .add(new QuarkColumn("web_rec_start_date", Types.DATE))
+            .add(new QuarkColumn("web_county", Types.VARCHAR))
+            .add(new QuarkColumn("web_tax_percentage", Types.DECIMAL)).build()
+    );
+
+    builder.put("WEB_SITE_PARTITION", web_site_partition);
     return builder.build();
   }
 }

--- a/optimizer/src/test/java/com/qubole/quark/planner/test/ViewsTest.java
+++ b/optimizer/src/test/java/com/qubole/quark/planner/test/ViewsTest.java
@@ -1,0 +1,91 @@
+package com.qubole.quark.planner.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.qubole.quark.QuarkException;
+import com.qubole.quark.planner.MetadataSchema;
+import com.qubole.quark.planner.QuarkSchema;
+import com.qubole.quark.planner.QuarkView;
+import com.qubole.quark.planner.TestFactory;
+import com.qubole.quark.planner.parser.SqlQueryParser;
+import com.qubole.quark.planner.test.utilities.QuarkTestUtil;
+import com.qubole.quark.sql.QueryContext;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Created by qubole on 4/27/16.
+ */
+public class ViewsTest {
+  private static final Logger log = LoggerFactory.getLogger(ViewsTest.class);
+  private static SqlQueryParser parser;
+  private static Properties info;
+
+  public static class ViewSchema extends MetadataSchema {
+    ViewSchema() {}
+
+    public QuarkView webSitePartition() {
+      final QuarkView view = new QuarkView("web_site_partition", "select web_site_sk, " +
+              "web_rec_start_date, web_county, web_tax_percentage from tpcds.web_site"
+             +  " where web_rec_start_date > '2015-06-29' AND ((web_county = 'en') or "
+             +  "(web_county = 'fr') or (web_county = 'ja') or (web_county = 'de') or "
+             + "(web_county = 'ru'))", "WEB_SITE_PARTITION",
+              ImmutableList.of("TPCDS"), ImmutableList.of("TPCDS", "WEB_SITE_PARTITION"));
+
+      return view;
+    }
+
+    @Override
+    public void initialize(QueryContext queryContext) throws QuarkException {
+      this.views = ImmutableList.of(webSitePartition());
+      this.cubes = ImmutableList.of();
+      super.initialize(queryContext);
+    }
+  }
+
+  public static class SchemaFactory extends TestFactory {
+    public SchemaFactory() {
+      super(new Tpcds("tpcds".toUpperCase()));
+    }
+    public List<QuarkSchema> create(Properties info) {
+      ViewSchema cubeSchema = new ViewSchema();
+      return new ImmutableList.Builder<QuarkSchema>()
+          .add(this.getDefaultSchema())
+          .add(cubeSchema).build();
+    }
+  }
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    info = new Properties();
+    info.put("unitTestMode", "true");
+    info.put("schemaFactory", "com.qubole.quark.planner.test.ViewsTest$SchemaFactory");
+
+    info.put("defaultSchema", QuarkTestUtil.toJson("TPCDS"));
+    parser = new SqlQueryParser(info);
+  }
+
+  @Test
+  public void usingWebSiteGroupOrderQuery() throws QuarkException, SQLException {
+    String query = "select web_rec_start_date, sum(web_tax_percentage), " +
+            "web_county from tpcds.web_site " +
+            "where web_rec_start_date > '2015-06-30' AND ((web_county = 'fr') or (web_county = " +
+            "'de')) group by web_rec_start_date, web_county " +
+            "order by web_rec_start_date";
+    QuarkTestUtil.checkParsedSql(
+            query,
+            info,
+            "SELECT WEB_REC_START_DATE, SUM(WEB_TAX_PERCENTAGE), WEB_COUNTY " +
+                "FROM TPCDS.WEB_SITE_PARTITION " +
+                "WHERE WEB_REC_START_DATE > '2015-06-30' " +
+                "AND (WEB_COUNTY = 'fr' OR WEB_COUNTY = 'de') " +
+                "GROUP BY WEB_REC_START_DATE, WEB_COUNTY " +
+                "ORDER BY WEB_REC_START_DATE");
+  }
+}


### PR DESCRIPTION
Couple of constraints added to rule:
1. Don't optimize the already optimized scans. This constraint is purely for efficiency and not to avoid Runtime Exception.
2. Don't optimize scans with different row types than the materialised views. Earlier assumption was that this constraint is taken care by MaterializedViewSubstitutor gracefully but apparently it does not and throws Assertion. This seems to be precondition for Substitutor.