### PR TITLE
fix: usr: #76: Schema details gets overwritten when fetched through Qubole's API

### DIFF
--- a/plugins/src/main/java/com/qubole/quark/plugins/qubole/DbTapDb.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/qubole/DbTapDb.java
@@ -73,7 +73,11 @@ public class DbTapDb extends QuboleDB {
     while (schemaListDescribed.getPaging_info().getNext_page() != null) {
       schemaListDescribed =  getQdsClient().dbTaps().getSchemaListDescribed(dbTapid)
               .forPage(current_page++, per_page).invoke().get();
-      schemas.putAll(schemaListDescribed.getSchemas());
+      /**
+       * Since the schema details can be distributed over multiple api calls,
+       * mergeSchemas method should be used, instead of Map.putAll
+       * */
+      schemas = mergeSchemas(schemas, schemaListDescribed.getSchemas());
     }
     return schemas;
   }

--- a/plugins/src/main/java/com/qubole/quark/plugins/qubole/HiveDb.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/qubole/HiveDb.java
@@ -67,7 +67,11 @@ public class HiveDb extends QuboleDB {
     while (schemaListDescribed.getPaging_info().getNext_page() != null) {
       schemaListDescribed =  getQdsClient().hiveMetadata().getSchemaListDescribed().
               forPage(current_page, per_page).invoke().get();
-      schemas.putAll(schemaListDescribed.getSchemas());
+      /**
+       * Since the schema details can be distributed over multiple api calls,
+       * mergeSchemas method should be used, instead of Map.putAll
+       * */
+      schemas = mergeSchemas(schemas, schemaListDescribed.getSchemas());
     }
     return schemas;
   }

--- a/plugins/src/main/java/com/qubole/quark/plugins/qubole/QuboleDB.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/qubole/QuboleDB.java
@@ -192,6 +192,33 @@ public abstract class QuboleDB implements Executor {
   }
 
   /**
+   * Merges two schema Maps. 'putAll' method can't be used because if the any of the
+   * key is same in the maps, then it will get overwritten.
+   * for e.g.
+   * if map1 = {'public' -> list1}, map2 = {'public' -> list2}
+   * then
+   *   map1.putAll(map2) will return map2 ({'public' -> list2})
+   *   i.e. map1 gets overwritten
+   *
+   * @param schemas1 schema map1
+   * @param schemas2 schema map2
+   *
+   * @return returns merged Map
+   * */
+  protected Map<String, List<SchemaOrdinal>> mergeSchemas(
+      Map<String, List<SchemaOrdinal>> schemas1,
+      Map<String, List<SchemaOrdinal>> schemas2) {
+    for (String schemaName : schemas2.keySet()) {
+      if (schemas1.containsKey(schemaName)) {
+        schemas1.get(schemaName).addAll(schemas2.get(schemaName));
+      } else {
+        schemas1.put(schemaName, schemas2.get(schemaName));
+      }
+    }
+    return schemas1;
+  }
+
+  /**
    * Created by dev on 11/13/15.
    */
   class ColumnComparator implements Comparator<NameTypePosition> {

--- a/plugins/src/main/java/com/qubole/quark/plugins/qubole/SparkDb.java
+++ b/plugins/src/main/java/com/qubole/quark/plugins/qubole/SparkDb.java
@@ -71,7 +71,11 @@ public class SparkDb extends QuboleDB {
     while (schemaListDescribed.getPaging_info().getNext_page() != null) {
       schemaListDescribed =  getQdsClient().hiveMetadata().getSchemaListDescribed().
               forPage(current_page, per_page).invoke().get();
-      schemas.putAll(schemaListDescribed.getSchemas());
+      /**
+       * Since the schema details can be distributed over multiple api calls,
+       * mergeSchemas method should be used, instead of Map.putAll
+       * */
+      schemas = mergeSchemas(schemas, schemaListDescribed.getSchemas());
     }
     return schemas;
   }


### PR DESCRIPTION
Dbtap, Spark and hive api's replaces the older schema details with the newer
one if the schema details are fetched over multiple api calls.