### PR TITLE
chg:dev:No issue:Create ParserFactory to get DDL/SqlQuery Parser

### DIFF
--- a/fatjdbc/src/main/java/com/qubole/quark/fatjdbc/executor/DDLPlanExecutor.java
+++ b/fatjdbc/src/main/java/com/qubole/quark/fatjdbc/executor/DDLPlanExecutor.java
@@ -98,27 +98,27 @@ public class DDLPlanExecutor extends PlanExecutor {
     }
     if (sqlNode instanceof SqlCreateQuarkDataSource) {
       int id = executeCreateDataSource((SqlCreateQuarkDataSource) sqlNode);
-      connection.resetSelectParser();
+      connection.setIsDirty();
       return QuarkMetaResultSet.count(h.connectionId, h.id, id);
     } else if (sqlNode instanceof SqlAlterQuarkDataSource) {
       int id = executeAlterDataSource((SqlAlterQuarkDataSource) sqlNode);
-      connection.resetSelectParser();
+      connection.setIsDirty();
       return QuarkMetaResultSet.count(h.connectionId, h.id, id);
     } else if (sqlNode instanceof SqlDropQuarkDataSource) {
       executeDeleteOnDataSource((SqlDropQuarkDataSource) sqlNode);
-      connection.resetSelectParser();
+      connection.setIsDirty();
       return QuarkMetaResultSet.count(h.connectionId, h.id, 0);
     } else if (sqlNode instanceof SqlCreateQuarkView) {
       int id = executeCreateView((SqlCreateQuarkView) sqlNode);
-      connection.resetSelectParser();
+      connection.setIsDirty();
       return QuarkMetaResultSet.count(h.connectionId, h.id, id);
     } else if (sqlNode instanceof SqlAlterQuarkView) {
       int id = executeAlterView((SqlAlterQuarkView) sqlNode);
-      connection.resetSelectParser();
+      connection.setIsDirty();
       return QuarkMetaResultSet.count(h.connectionId, h.id, id);
     } else if (sqlNode instanceof SqlDropQuarkView) {
       executeDeleteOnView((SqlDropQuarkView) sqlNode);
-      connection.resetSelectParser();
+      connection.setIsDirty();
       return QuarkMetaResultSet.count(h.connectionId, h.id, 0);
     } else if (sqlNode instanceof SqlShowQuark) {
       return getQuarkMetaResultSetForDDL((SqlShowQuark) sqlNode, result);

--- a/optimizer/src/main/java/com/qubole/quark/planner/parser/DDLParser.java
+++ b/optimizer/src/main/java/com/qubole/quark/planner/parser/DDLParser.java
@@ -22,7 +22,7 @@ import org.apache.calcite.sql.SqlKind;
  *
  * Parser for Quark's DDL Statements
  */
-public class DDLParser {
+public class DDLParser implements Parser {
   public DDLParserResult parse(String sql) {
     return new DDLParserResult(sql,
         SqlKind.OTHER_DDL, null, true);

--- a/optimizer/src/main/java/com/qubole/quark/planner/parser/ParserFactory.java
+++ b/optimizer/src/main/java/com/qubole/quark/planner/parser/ParserFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2015. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.qubole.quark.planner.parser;
+
+import org.apache.calcite.avatica.util.Casing;
+import org.apache.calcite.avatica.util.Quoting;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
+
+import com.qubole.quark.QuarkException;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+/**
+ * Created by adeshr on 5/24/16.
+ */
+public class ParserFactory {
+  private SqlQueryParser sqlQueryParser;
+
+  public SqlQueryParser getSqlQueryParser(Properties info, boolean reloadCache)
+      throws SQLException {
+    if (reloadCache || sqlQueryParser == null) {
+      try {
+        sqlQueryParser = new SqlQueryParser(info);
+      } catch (QuarkException e) {
+        throw new SQLException(e.getMessage(), e);
+      }
+    }
+    return sqlQueryParser;
+  }
+
+  public Parser getParser(String sql, Properties info, boolean reloadCache)
+      throws SQLException {
+    SqlParser parser = SqlParser.create(sql,
+        SqlParser.configBuilder()
+            .setQuotedCasing(Casing.UNCHANGED)
+            .setUnquotedCasing(Casing.UNCHANGED)
+            .setQuoting(Quoting.DOUBLE_QUOTE)
+            .build());
+    SqlNode sqlNode;
+    try {
+      sqlNode = parser.parseStmt();
+    } catch (SqlParseException e) {
+      throw new RuntimeException(
+          "parse failed: " + e.getMessage(), e);
+    }
+    if (sqlNode.getKind().equals(SqlKind.OTHER_DDL)) {
+      return new DDLParser();
+    } else  {
+      return getSqlQueryParser(info, reloadCache);
+    }
+  }
+}

--- a/server/src/test/java/com/qubole/quark/server/MigrationTest.java
+++ b/server/src/test/java/com/qubole/quark/server/MigrationTest.java
@@ -76,6 +76,13 @@ public class MigrationTest {
       }
     }
 
+    // Executing a random query to migrate the db
+    try {
+      connection.createStatement().executeQuery("select * from non_existent_table");
+    } catch (Exception e) {
+      assertThat(e.getMessage(), containsString("Table 'NON_EXISTENT_TABLE' not found"));
+    }
+
     connection = DriverManager.getConnection(dbUrl, "sa", "");
     stmt = connection.createStatement();
     ResultSet version = stmt.executeQuery("select count(*) from \"schema_version\"");


### PR DESCRIPTION
ParserFactory will return the DDL/SqlQuery parser based on the sql query. The factory will store SqlQueryParser state (for caching purpose) and creates new instance only if connection info changes.
Also, added attribute `type` in ParserResult to distinguish between DDL/SelectQuery. 