### PR TITLE
chg:usr:#87:Standardize syntax of DROP & SHOW. Add multi-tenant support

### DIFF
--- a/catalog/src/main/java/com/qubole/quark/catalog/db/Connection.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/Connection.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2015. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.qubole.quark.catalog.db;
+
+import com.qubole.quark.QuarkException;
+import com.qubole.quark.catalog.db.dao.DSSetDAO;
+import com.qubole.quark.catalog.db.encryption.AESEncrypt;
+import com.qubole.quark.catalog.db.encryption.NoopEncrypt;
+import com.qubole.quark.catalog.db.pojo.DSSet;
+
+import org.flywaydb.core.Flyway;
+
+import org.skife.jdbi.v2.DBI;
+
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Created by rajatv on 6/1/16.
+ */
+public class Connection {
+  private final DBI dbi;
+  private final Properties info;
+  private DSSet dsSet;
+
+  public Connection(Properties info) {
+    this.info = info;
+    this.dbi = new DBI(
+        info.getProperty("url"),
+        info.getProperty("user"),
+        info.getProperty("password"));
+
+    if (Boolean.parseBoolean(info.getProperty("encrypt", "false"))) {
+      dbi.define("encryptClass", new AESEncrypt(info.getProperty("encryptionKey")));
+    } else {
+      dbi.define("encryptClass", new NoopEncrypt());
+    }
+  }
+
+  public void runFlyWay() {
+    Flyway flyway = new Flyway();
+    flyway.setDataSource(
+        info.getProperty("url"),
+        info.getProperty("user"),
+        info.getProperty("password"));
+    flyway.migrate();
+  }
+
+  public DSSet getDSSet() {
+    if (this.dsSet == null) {
+      DSSetDAO dsSetDAO = dbi.onDemand(DSSetDAO.class);
+      if (info.containsKey("dsSetId")) {
+        this.dsSet = dsSetDAO.find(Integer.parseInt(info.getProperty("dsSetId")));
+      } else {
+        List<DSSet> dsSets = dsSetDAO.findAll();
+        this.dsSet = dsSets.get(0);
+      }
+      dbi.define("dsSetId", dsSet.getId());
+    }
+    return dsSet;
+  }
+
+  public DBI getDbi() throws QuarkException {
+    if (dsSet == null) {
+      throw new QuarkException("DB Catalog not initialized correctly. DSSet is not found");
+    }
+    return this.dbi;
+  }
+}

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/dao/DataSourceDAO.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/dao/DataSourceDAO.java
@@ -53,7 +53,7 @@ public abstract class DataSourceDAO {
   public abstract int update(@BindBean("d") DataSource ds);
 
   @SqlUpdate("delete from data_sources where id = :id")
-  public abstract void delete(@Bind("id") int id);
+  public abstract void delete(@Bind("id") long id);
 
   public int insertJDBC(String name, String type, String url, long dsSetId,
                         String dataSourcetype, JdbcSourceDAO jdbcDao, String username,

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/dao/JdbcSourceDAO.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/dao/JdbcSourceDAO.java
@@ -25,7 +25,6 @@ import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.Transaction;
-import org.skife.jdbi.v2.sqlobject.customizers.Define;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 
@@ -42,6 +41,12 @@ public abstract class JdbcSourceDAO {
       + "js.username, js.password from data_sources ds join jdbc_sources js on ds.id = js.id "
       + "where ds.ds_set_id = :ds_set_id")
   public abstract List<JdbcSource> findByDSSetId(@Bind("ds_set_id") long dsSetId);
+
+  @SqlQuery("select ds.id, ds.name, ds.type, ds.datasource_type, ds.url, ds.ds_set_id, "
+      + "js.username, js.password from data_sources ds join jdbc_sources js on ds.id = js.id "
+      + "where ds.name like :like_pattern and ds.ds_set_id = :ds_set_id")
+  public abstract List<JdbcSource> findLikeName(@Bind("like_pattern") String likePattern,
+                                                @Bind("ds_set_id") long dsSetId);
 
   @SqlQuery("select ds.id, ds.name, ds.type, ds.datasource_type, ds.url, ds.ds_set_id, "
       + "js.username, js.password from data_sources ds join jdbc_sources js on ds.id = js.id "
@@ -72,9 +77,4 @@ public abstract class JdbcSourceDAO {
     updateJdbc(source);
     return dao.update(source);
   }
-
-  @SqlQuery("select data_sources.id, name, type, datasource_type, url, ds_set_id, "
-      + "jdbc_sources.username, jdbc_sources.password from data_sources join jdbc_sources "
-      + "on data_sources.id = jdbc_sources.id <where>")
-  public abstract List<JdbcSource> findByWhere(@Define("where") String where);
 }

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/dao/JdbcSourceDAO.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/dao/JdbcSourceDAO.java
@@ -53,6 +53,11 @@ public abstract class JdbcSourceDAO {
       + "where ds.id = :id and ds.ds_set_id = :ds_set_id")
   public abstract JdbcSource find(@Bind("id") int id, @Bind("ds_set_id") long dsSetId);
 
+  @SqlQuery("select ds.id, ds.name, ds.type, ds.datasource_type, ds.url, ds.ds_set_id, "
+      + "js.username, js.password from data_sources ds join jdbc_sources js on ds.id = js.id "
+      + "where ds.name = :name and ds.ds_set_id = :ds_set_id")
+  public abstract JdbcSource findByName(@Bind("name") String name, @Bind("ds_set_id") long dsSetId);
+
   @SqlUpdate("insert into jdbc_sources(id, username, password) values(:id, :username, :password)")
   abstract void insert(@Bind("id") long id, @Bind("username") String username,
       @Bind("password") String password);
@@ -63,7 +68,7 @@ public abstract class JdbcSourceDAO {
   protected abstract int updateJdbc(@BindBean("j") JdbcSource source);
 
   @SqlUpdate("delete from jdbc_sources where id = :id")
-  public abstract void delete(@Bind("id") int id);
+  public abstract void delete(@Bind("id") long id);
 
   @Transaction
   public int update(JdbcSource source, DataSourceDAO dao, Encrypt encrypt) {

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/dao/JdbcSourceDAO.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/dao/JdbcSourceDAO.java
@@ -45,8 +45,8 @@ public abstract class JdbcSourceDAO {
 
   @SqlQuery("select ds.id, ds.name, ds.type, ds.datasource_type, ds.url, ds.ds_set_id, "
       + "js.username, js.password from data_sources ds join jdbc_sources js on ds.id = js.id "
-      + "where ds.id = :id")
-  public abstract JdbcSource find(@Bind("id") int id);
+      + "where ds.id = :id and ds.ds_set_id = :ds_set_id")
+  public abstract JdbcSource find(@Bind("id") int id, @Bind("ds_set_id") long dsSetId);
 
   @SqlUpdate("insert into jdbc_sources(id, username, password) values(:id, :username, :password)")
   abstract void insert(@Bind("id") long id, @Bind("username") String username,

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/dao/QuboleDbSourceDAO.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/dao/QuboleDbSourceDAO.java
@@ -45,8 +45,8 @@ public abstract class QuboleDbSourceDAO {
 
   @SqlQuery("select ds.id, ds.name, ds.type, ds.datasource_type, ds.url, ds.ds_set_id, "
       + "qs.dbtap_id, qs.auth_token from data_sources ds join quboledb_sources qs on ds.id = qs.id "
-      + "where ds.id = :id")
-  public abstract QuboleDbSource find(@Bind("id") int id);
+      + "where ds.id = :id and ds.ds_set_id = :ds_set_id")
+  public abstract QuboleDbSource find(@Bind("id") int id, @Bind("ds_set_id") long dsSetId);
 
   @SqlUpdate("insert into quboledb_sources(id, dbtap_id, auth_token) "
       + "values(:id, :dbtap_id, :auth_token)")

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/dao/QuboleDbSourceDAO.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/dao/QuboleDbSourceDAO.java
@@ -53,6 +53,12 @@ public abstract class QuboleDbSourceDAO {
       + "where ds.id = :id and ds.ds_set_id = :ds_set_id")
   public abstract QuboleDbSource find(@Bind("id") int id, @Bind("ds_set_id") long dsSetId);
 
+  @SqlQuery("select ds.id, ds.name, ds.type, ds.datasource_type, ds.url, ds.ds_set_id, "
+      + "qs.dbtap_id, qs.auth_token from data_sources ds join quboledb_sources qs on ds.id = qs.id "
+      + "where ds.name = :name and ds.ds_set_id = :ds_set_id")
+  public abstract QuboleDbSource findByName(@Bind("name") String name,
+                                            @Bind("ds_set_id") long dsSetId);
+
   @SqlUpdate("insert into quboledb_sources(id, dbtap_id, auth_token) "
       + "values(:id, :dbtap_id, :auth_token)")
   public abstract void insert(@Bind("id") long id, @Bind("dbtap_id") int dbTapId,
@@ -64,7 +70,7 @@ public abstract class QuboleDbSourceDAO {
   protected abstract int updateQubole(@BindBean("d") QuboleDbSource db);
 
   @SqlUpdate("delete from quboledb_sources where id = :id")
-  public abstract void delete(@Bind("id") int id);
+  public abstract void delete(@Bind("id") long id);
 
   @Transaction
   public int update(QuboleDbSource db, DataSourceDAO dao, Encrypt encrypt) {

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/dao/QuboleDbSourceDAO.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/dao/QuboleDbSourceDAO.java
@@ -25,7 +25,6 @@ import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.Transaction;
-import org.skife.jdbi.v2.sqlobject.customizers.Define;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 
@@ -42,6 +41,12 @@ public abstract class QuboleDbSourceDAO {
       + "qs.dbtap_id, qs.auth_token from data_sources ds join quboledb_sources qs on ds.id = qs.id "
       + "where ds.ds_set_id = :ds_set_id")
   public abstract List<QuboleDbSource> findByDSSetId(@Bind("ds_set_id") long dsSetId);
+
+  @SqlQuery("select ds.id, ds.name, ds.type, ds.datasource_type, ds.url, ds.ds_set_id, "
+      + "qs.dbtap_id, qs.auth_token from data_sources ds join quboledb_sources qs on ds.id = qs.id "
+      + "where ds.name like :like_pattern and ds.ds_set_id = :ds_set_id")
+  public abstract List<QuboleDbSource> findLikeName(@Bind("like_pattern") String likePattern,
+                                                          @Bind("ds_set_id") long dsSetId);
 
   @SqlQuery("select ds.id, ds.name, ds.type, ds.datasource_type, ds.url, ds.ds_set_id, "
       + "qs.dbtap_id, qs.auth_token from data_sources ds join quboledb_sources qs on ds.id = qs.id "
@@ -72,9 +77,4 @@ public abstract class QuboleDbSourceDAO {
     updateQubole(db);
     return dao.update(db);
   }
-
-  @SqlQuery("select data_sources.id, name, type, datasource_type, url, ds_set_id, "
-      + "quboledb_sources.dbtap_id, quboledb_sources.auth_token from data_sources "
-      + "join quboledb_sources on data_sources.id = quboledb_sources.id <where>")
-  public abstract List<QuboleDbSource> findByWhere(@Define("where") String where);
 }

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/dao/ViewDAO.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/dao/ViewDAO.java
@@ -43,8 +43,8 @@ public interface ViewDAO {
 
   @SqlQuery("select p.id, p.name, p.description, p.query, p.cost, p.table_name, p.schema_name, "
       + "p.destination_id, ds.name as destination, p.ds_set_id from data_sources ds join "
-      + "partitions p on p.destination_id = ds.id where p.id = :id")
-  View find(@Bind("id")long id);
+      + "partitions p on p.destination_id = ds.id where p.id = :id and ds.ds_set_id = :ds_set_id")
+  View find(@Bind("id")long id, @Bind("ds_set_id") long dsSetId);
 
   @GetGeneratedKeys
   @SqlUpdate("insert into partitions(name, description, query, cost, destination_id, "
@@ -55,16 +55,15 @@ public interface ViewDAO {
              @Bind("destination_id") long destinationId, @Bind("schema_name") String schemaName,
              @Bind("table_name") String tableName, @Bind("ds_set_id") long dsSetId);
 
-  @GetGeneratedKeys
   @SqlUpdate("update partitions set name = :v.name, description = :v.description, "
-      + "query = :v.query, cost = :v.cost, schema_name = :v.schema, ds_set_id = :v.dsSetId, "
-      + "table_name = :v.table, destination_id = :v.destinationId where id = :v.id")
-  int update(@BindBean("v") View view);
+      + "query = :v.query, cost = :v.cost, schema_name = :v.schema, "
+      + "table_name = :v.table, destination_id = :v.destinationId where id = :v.id and ds_set_id = :ds_set_id")
+  int update(@BindBean("v") View view, @Bind("ds_set_id") long dsSetId);
 
-  @SqlUpdate("delete from partitions where id = :id")
-  void delete(@Bind("id") int id);
+  @SqlUpdate("delete from partitions where id = :id and ds_set_id = :ds_set_id")
+  void delete(@Bind("id") int id, @Bind("ds_set_id") long dsSetId);
 
   @SqlQuery("select id, name, description, query, cost, table_name, schema_name, "
-      + "destination_id, null as destination, ds_set_id from partitions <where>")
-  List<View> findByWhere(@Define("where") String where);
+      + "destination_id, null as destination, ds_set_id from partitions where ds_set_id = :ds_set_id <where>")
+  List<View> findByWhere(@Define("where") String where, @Bind("ds_set_id") long dsSetId);
 }

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/dao/ViewDAO.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/dao/ViewDAO.java
@@ -23,7 +23,6 @@ import org.skife.jdbi.v2.sqlobject.BindBean;
 import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
-import org.skife.jdbi.v2.sqlobject.customizers.Define;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 
@@ -40,6 +39,11 @@ public interface ViewDAO {
       + "p.destination_id, ds.name as destination, p.ds_set_id from data_sources ds join "
       + "partitions p on p.destination_id = ds.id where ds.ds_set_id = :ds_set_id")
   List<View> findByDSSetId(@Bind("ds_set_id")long dsSetId);
+
+  @SqlQuery("select p.id, p.name, p.description, p.query, p.cost, p.table_name, p.schema_name, "
+      + "p.destination_id, ds.name as destination, p.ds_set_id from data_sources ds join "
+      + "partitions p on p.destination_id = ds.id where p.name like :like_pattern and ds.ds_set_id = :ds_set_id")
+  List<View> findLikeName(@Bind("like_pattern") String likePattern, @Bind("ds_set_id")long dsSetId);
 
   @SqlQuery("select p.id, p.name, p.description, p.query, p.cost, p.table_name, p.schema_name, "
       + "p.destination_id, ds.name as destination, p.ds_set_id from data_sources ds join "
@@ -62,8 +66,4 @@ public interface ViewDAO {
 
   @SqlUpdate("delete from partitions where id = :id and ds_set_id = :ds_set_id")
   void delete(@Bind("id") int id, @Bind("ds_set_id") long dsSetId);
-
-  @SqlQuery("select id, name, description, query, cost, table_name, schema_name, "
-      + "destination_id, null as destination, ds_set_id from partitions where ds_set_id = :ds_set_id <where>")
-  List<View> findByWhere(@Define("where") String where, @Bind("ds_set_id") long dsSetId);
 }

--- a/catalog/src/main/java/com/qubole/quark/catalog/db/dao/ViewDAO.java
+++ b/catalog/src/main/java/com/qubole/quark/catalog/db/dao/ViewDAO.java
@@ -64,6 +64,6 @@ public interface ViewDAO {
       + "table_name = :v.table, destination_id = :v.destinationId where id = :v.id and ds_set_id = :ds_set_id")
   int update(@BindBean("v") View view, @Bind("ds_set_id") long dsSetId);
 
-  @SqlUpdate("delete from partitions where id = :id and ds_set_id = :ds_set_id")
-  void delete(@Bind("id") int id, @Bind("ds_set_id") long dsSetId);
+  @SqlUpdate("delete from partitions where name = :name and ds_set_id = :ds_set_id")
+  void delete(@Bind("name") String name, @Bind("ds_set_id") long dsSetId);
 }

--- a/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/JdbcSourceTest.java
+++ b/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/JdbcSourceTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Created by adeshr on 2/17/16.
@@ -41,6 +42,7 @@ public class JdbcSourceTest extends DbUtility {
       IOException, URISyntaxException {
 
     setUpDb(dbSchemaUrl, "sa", "", "tpcds.sql");
+    setUpDb(dbSchemaUrl, "sa", "", "tpcds_2.sql");
 
     DBI dbi = new DBI(dbSchemaUrl, "sa", "");
     jdbcSourceDAO = dbi.onDemand(JdbcSourceDAO.class);
@@ -52,4 +54,25 @@ public class JdbcSourceTest extends DbUtility {
     List<JdbcSource> jdbcSources = jdbcSourceDAO.findByDSSetId(1);
     assertThat(jdbcSources.size(), equalTo(3));
   }
+
+  @Test
+  public void testGetSuccessOn1() {
+    JdbcSource jdbcSource = jdbcSourceDAO.find(1, 1);
+    assertThat(jdbcSource.getName(), equalTo("CANONICAL"));
+    assertThat(jdbcSource.getDsSetId(), equalTo(1L));
+  }
+
+  @Test
+  public void testGetSuccessOn2() {
+    JdbcSource jdbcSource = jdbcSourceDAO.find(5, 10);
+    assertThat(jdbcSource.getName(), equalTo("CANONICAL"));
+    assertThat(jdbcSource.getDsSetId(), equalTo(10L));
+  }
+
+  @Test
+  public void testGetFail() {
+    JdbcSource jdbcSource = jdbcSourceDAO.find(1, 10);
+    assertThat(jdbcSource, nullValue());
+  }
+
 }

--- a/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/QuboleDbSourceTest.java
+++ b/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/QuboleDbSourceTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Created by adeshr on 2/17/16.
@@ -41,6 +42,7 @@ public class QuboleDbSourceTest extends DbUtility {
       IOException, URISyntaxException {
 
     setUpDb(dbSchemaUrl, "sa", "", "tpcds.sql");
+    setUpDb(dbSchemaUrl, "sa", "", "tpcds_2.sql");
 
     DBI dbi = new DBI(dbSchemaUrl, "sa", "");
     quboleDbSourceDAO = dbi.onDemand(QuboleDbSourceDAO.class);
@@ -52,4 +54,25 @@ public class QuboleDbSourceTest extends DbUtility {
     List<QuboleDbSource> quboleDbSources = quboleDbSourceDAO.findByDSSetId(1);
     assertThat(quboleDbSources.size(), equalTo(1));
   }
+
+  @Test
+  public void testGetSuccessOn1() {
+    QuboleDbSource quboleDbSource = quboleDbSourceDAO.find(4, 1);
+    assertThat(quboleDbSource.getName(), equalTo("TEST"));
+    assertThat(quboleDbSource.getDsSetId(), equalTo(1L));
+  }
+
+  @Test
+  public void testGetSuccessOn2() {
+    QuboleDbSource quboleDbSource = quboleDbSourceDAO.find(8, 10);
+    assertThat(quboleDbSource.getName(), equalTo("TEST_10"));
+    assertThat(quboleDbSource.getDsSetId(), equalTo(10L));
+  }
+
+  @Test
+  public void testGetFail() {
+    QuboleDbSource quboleDbSource = quboleDbSourceDAO.find(8, 1);
+    assertThat(quboleDbSource, nullValue());
+  }
+
 }

--- a/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/ViewTest.java
+++ b/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/ViewTest.java
@@ -108,24 +108,4 @@ public class ViewTest extends DbUtility {
     View view = viewDAO.find(3, 1);
     assertThat(view, notNullValue());
   }
-
-  @Test
-  public void whereSuccessOn1() {
-    List<View> views = viewDAO.findByWhere("and name='warehouse_part'", 1);
-    assertThat(views.size(), equalTo(1));
-    assertThat(views.get(0).getDsSetId(), equalTo(1L));
-  }
-
-  @Test
-  public void whereSuccessOn10() {
-    List<View> views = viewDAO.findByWhere("and name='warehouse_part'", 10);
-    assertThat(views.size(), equalTo(1));
-    assertThat(views.get(0).getDsSetId(), equalTo(10L));
-  }
-
-  @Test
-  public void whereFailureOn1() {
-    List<View> views = viewDAO.findByWhere("and name='customer_address_part_10'", 1);
-    assertThat(views, Matchers.<View>empty());
-  }
 }

--- a/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/ViewTest.java
+++ b/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/ViewTest.java
@@ -97,14 +97,14 @@ public class ViewTest extends DbUtility {
 
   @Test
   public void testDeleteSuccessOn1() {
-    viewDAO.delete(7, 10);
+    viewDAO.delete("customer_address_part_10", 10);
     View view = viewDAO.find(7, 10);
     assertThat(view, nullValue());
   }
 
   @Test
   public void testDeleteFailureOn1() {
-    viewDAO.delete(3, 10);
+    viewDAO.delete("customer_address_part", 10);
     View view = viewDAO.find(3, 1);
     assertThat(view, notNullValue());
   }

--- a/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/ViewTest.java
+++ b/catalog/src/test/java/com/qubole/quark/catalog/db/pojo/ViewTest.java
@@ -15,8 +15,8 @@
 
 package com.qubole.quark.catalog.db.pojo;
 
-import com.qubole.quark.catalog.db.RelSchema;
 import com.qubole.quark.catalog.db.dao.ViewDAO;
+import org.hamcrest.Matchers;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
@@ -28,6 +28,8 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Created by adeshr on 2/17/16.
@@ -41,14 +43,89 @@ public class ViewTest extends DbUtility {
       IOException, URISyntaxException {
 
     setUpDb(dbSchemaUrl, "sa", "", "tpcds.sql");
+    setUpDb(dbSchemaUrl, "sa", "", "tpcds_2.sql");
 
     DBI dbi = new DBI(dbSchemaUrl, "sa", "");
     viewDAO = dbi.onDemand(ViewDAO.class);
   }
 
   @Test
-  public void testGet() {
+  public void testGetAll() {
     List<View> views = viewDAO.findByDSSetId(1);
     assertThat(views.size(), equalTo(4));
+  }
+
+  @Test
+  public void testGetSuccessOn1() {
+    View view = viewDAO.find(1, 1);
+    assertThat(view.getName(), equalTo("warehouse_part"));
+    assertThat(view.getDestinationId(), equalTo(3L));
+  }
+
+  @Test
+  public void testGetSuccessOn2() {
+    View view = viewDAO.find(6, 10);
+    assertThat(view.getName(), equalTo("web_sales_part"));
+    assertThat(view.getDestinationId(), equalTo(7L));
+  }
+
+  @Test
+  public void testGetFail() {
+    View view = viewDAO.find(1, 10);
+    assertThat(view, nullValue());
+  }
+
+  @Test
+  public void testUpdateSuccessOn1() {
+    View view = viewDAO.find(1, 1);
+    view.setName("new_name");
+    int updated = viewDAO.update(view, 1);
+    assertThat(updated, equalTo(1));
+    View updatedView = viewDAO.find(1, 1);
+    assertThat(updatedView.getName(), equalTo("new_name"));
+  }
+
+  @Test
+  public void testUpdateFailureOn1() {
+    View view = viewDAO.find(1, 1);
+    view.setName("new_name");
+    int updated = viewDAO.update(view, 10);
+    assertThat(updated, equalTo(0));
+    View updatedView = viewDAO.find(1, 1);
+    assertThat(updatedView.getName(), equalTo("warehouse_part"));
+  }
+
+  @Test
+  public void testDeleteSuccessOn1() {
+    viewDAO.delete(7, 10);
+    View view = viewDAO.find(7, 10);
+    assertThat(view, nullValue());
+  }
+
+  @Test
+  public void testDeleteFailureOn1() {
+    viewDAO.delete(3, 10);
+    View view = viewDAO.find(3, 1);
+    assertThat(view, notNullValue());
+  }
+
+  @Test
+  public void whereSuccessOn1() {
+    List<View> views = viewDAO.findByWhere("and name='warehouse_part'", 1);
+    assertThat(views.size(), equalTo(1));
+    assertThat(views.get(0).getDsSetId(), equalTo(1L));
+  }
+
+  @Test
+  public void whereSuccessOn10() {
+    List<View> views = viewDAO.findByWhere("and name='warehouse_part'", 10);
+    assertThat(views.size(), equalTo(1));
+    assertThat(views.get(0).getDsSetId(), equalTo(10L));
+  }
+
+  @Test
+  public void whereFailureOn1() {
+    List<View> views = viewDAO.findByWhere("and name='customer_address_part_10'", 1);
+    assertThat(views, Matchers.<View>empty());
   }
 }

--- a/catalog/src/test/resources/tpcds.sql
+++ b/catalog/src/test/resources/tpcds.sql
@@ -6,7 +6,7 @@ insert into data_sources(name, type, url, ds_set_id, datasource_type) values ('T
 insert into jdbc_sources(id, username, password) values(1, '96D37AB243836DBE4D804658D0862476', 'AA698221A5A25D0EDCAF50A3AD8EB6F4');
 insert into jdbc_sources(id, username, password) values(2, '96D37AB243836DBE4D804658D0862476', 'AA698221A5A25D0EDCAF50A3AD8EB6F4');
 insert into jdbc_sources(id, username, password) values(3, '96D37AB243836DBE4D804658D0862476', 'AA698221A5A25D0EDCAF50A3AD8EB6F4');
-insert into quboledb_sources(id, auth_token, dbtap_id) values(3, '087B44B33A051FD17A7EF8D204093446', 1234);
+insert into quboledb_sources(id, auth_token, dbtap_id) values(4, '087B44B33A051FD17A7EF8D204093446', 1234);
 
 insert into cubes(`name`, `description`, `cost`, `query`, `ds_set_id`, `destination_id`, `schema_name`,
 `table_name`, `grouping_column`)

--- a/catalog/src/test/resources/tpcds_2.sql
+++ b/catalog/src/test/resources/tpcds_2.sql
@@ -1,0 +1,66 @@
+insert into ds_sets(id, name, default_datasource_id) values(10, 'ds_10', 5);
+
+insert into data_sources(name, type, url, ds_set_id, datasource_type) values ('CANONICAL', 'H2', '087B44B33A051FD17A7EF8D204093446', 10, 'JDBC');
+insert into data_sources(name, type, url, ds_set_id, datasource_type) values ('CUBES', 'H2', '087B44B33A051FD17A7EF8D204093446', 10, 'JDBC');
+insert into data_sources(name, type, url, ds_set_id, datasource_type) values ('VIEWS', 'H2', '087B44B33A051FD17A7EF8D204093446', 10, 'JDBC');
+insert into data_sources(name, type, url, ds_set_id, datasource_type) values ('TEST_10', 'H2', '087B44B33A051FD17A7EF8D204093446', 10, 'QuboleDb');
+
+insert into jdbc_sources(id, username, password) values(5, '96D37AB243836DBE4D804658D0862476', 'AA698221A5A25D0EDCAF50A3AD8EB6F4');
+insert into jdbc_sources(id, username, password) values(6, '96D37AB243836DBE4D804658D0862476', 'AA698221A5A25D0EDCAF50A3AD8EB6F4');
+insert into jdbc_sources(id, username, password) values(7, '96D37AB243836DBE4D804658D0862476', 'AA698221A5A25D0EDCAF50A3AD8EB6F4');
+insert into quboledb_sources(id, auth_token, dbtap_id) values(8, '087B44B33A051FD17A7EF8D204093446', 1234);
+
+insert into cubes(`name`, `description`, `cost`, `query`, `ds_set_id`, `destination_id`, `schema_name`,
+`table_name`, `grouping_column`)
+    VALUES('web_returns_cubes', 'Web returns', 0,
+    'select 1 from canonical.public.web_returns as w join canonical.public.item as i on w.wr_item_sk = i.i_item_sk join canonical.public.customer as c on w.wr_refunded_cdemo_sk = c.c_customer_sk join canonical.public.date_dim as dd on w.wr_returned_date_sk = dd.d_date_sk join canonical.public.customer_demographics cd on c.c_current_cdemo_sk = cd.cd_demo_sk',
+    10, 6, 'PUBLIC', 'WEB_RETURNS_CUBE', 'GROUPING__ID');
+
+insert into dimensions(`name`, `cube_id`, `schema_name`, `table_name`, `column_name`, `cube_column_name`, `dimension_order`)
+    values('Item Id', 2, '', 'i', 'i_item_id', 'I_ITEM_ID', 0);
+insert into dimensions(`name`, `cube_id`, `schema_name`, `table_name`, `column_name`, `cube_column_name`, `dimension_order`)
+    values('Gender', 2, '', 'cd', 'cd_gender', 'CD_GENDER', 5);
+insert into dimensions(`name`, `cube_id`, `schema_name`, `table_name`, `column_name`, `cube_column_name`, `dimension_order`)
+    values('Marital Status', 2, '', 'cd', 'cd_marital_status', 'CD_MARITAL_STATUS', 6);
+insert into dimensions(`name`, `cube_id`, `schema_name`, `table_name`, `column_name`, `cube_column_name`, `dimension_order`)
+    values('Education Status', 2, '', 'cd', 'cd_education_status', 'CD_EDUCATION_STATUS', 7);
+insert into dimensions(`name`, `cube_id`, `schema_name`, `table_name`, `column_name`, `cube_column_name`, `dimension_order`)
+    values('Year', 2, '', 'dd', 'd_year', 'D_YEAR', 1);
+insert into dimensions(`name`, `cube_id`, `schema_name`, `table_name`, `column_name`, `cube_column_name`, `dimension_order`)
+    values('Quarter', 2, '', 'dd', 'd_qoy', 'D_QOY', 2);
+insert into dimensions(`name`, `cube_id`, `schema_name`, `table_name`, `column_name`, `cube_column_name`, `dimension_order`)
+    values('Month', 2, '', 'dd', 'd_moy', 'D_MOY', 3);
+insert into dimensions(`name`, `cube_id`, `schema_name`, `table_name`, `column_name`, `cube_column_name`, `dimension_order`)
+    values('Date', 2, '', 'dd', 'd_date', 'D_DATE', 4);
+
+
+insert into measures(`name`, `cube_id`, `column_name`, `function`, `cube_column_name`)
+    values ('Net Loss', 2, 'wr_net_loss', 'sum', 'TOTAL_NET_LOSS');
+insert into measures(`name`, `cube_id`, `column_name`, `function`, `cube_column_name`)
+    values ('Avergae Net Loss', 2, 'wr_net_loss', 'avg', 'AVERAGE_NET_LOSS');
+insert into measures(`name`, `cube_id`, `column_name`, `function`, `cube_column_name`)
+    values ('Min Return Amount', 2, 'wr_return_amt', 'min', 'MIN_RETURN_AMOUNT');
+insert into measures(`name`, `cube_id`, `column_name`, `function`, `cube_column_name`)
+    values ('Max Return Amount', 2, 'wr_return_amt', 'max', 'MAX_RETURN_AMOUNT');
+insert into measures(`name`, `cube_id`, `column_name`, `function`, `cube_column_name`)
+    values ('Web Page Count', 2, 'wr_web_page_sk', 'count', 'WEB_PAGE_COUNT');
+
+insert into partitions(`name`, `description`, `cost`, `query`, `ds_set_id`, `destination_id`,
+`schema_name`, `table_name`)
+    VALUES('warehouse_part', 'Warehouse Partition', 0,
+    'select * from canonical.public.warehouse as wr where  wr.w_warehouse_sq_ft > 100',
+    10, 7, 'PUBLIC', 'WAREHOUSE_PARTITION');
+
+insert into partitions(`name`, `description`, `cost`, `query`, `ds_set_id`, `destination_id`,
+`schema_name`, `table_name`)
+    VALUES('web_sales_part', 'WebSales Partition', 0,
+    'select * from canonical.public.web_sales as w where w.ws_quantity < 5 AND (w.ws_net_profit  > 2000 OR w.ws_wholesale_cost > 10000)',
+    10, 7, 'PUBLIC', 'WEB_SALES_PARTITION');
+
+
+insert into partitions(`name`, `description`, `cost`, `query`, `ds_set_id`, `destination_id`,
+`schema_name`, `table_name`)
+    VALUES('customer_address_part_10', 'Customer Address Partition', 0,
+    'select * from canonical.public.customer_address as c where c.ca_street_name=''commercialstreet'' OR c.ca_zip = ''560073''',
+    10, 7, 'PUBLIC', 'CUSTOMER_ADDRESS_PARTITION');
+

--- a/ee/src/main/java/com/qubole/quark/ee/QuarkDDLExecutor.java
+++ b/ee/src/main/java/com/qubole/quark/ee/QuarkDDLExecutor.java
@@ -495,7 +495,7 @@ public class QuarkDDLExecutor implements QuarkExecutor {
     DBI dbi = getDbi();
     String pojoType = sqlNode.getOperator().toString();
     String whereClause = (sqlNode.getCondition() == null)
-        ? "" : "where " + sqlNode.getCondition();
+        ? "" : "and " + sqlNode.getCondition();
 
     switch (pojoType) {
       case "SHOW_DATASOURCE":

--- a/ee/src/main/java/com/qubole/quark/ee/QuarkDDLExecutor.java
+++ b/ee/src/main/java/com/qubole/quark/ee/QuarkDDLExecutor.java
@@ -155,9 +155,9 @@ public class QuarkDDLExecutor implements QuarkExecutor {
     DataSourceDAO dataSourceDAO = dbi.onDemand(DataSourceDAO.class);
     JdbcSourceDAO jdbcDAO = dbi.onDemand(JdbcSourceDAO.class);
     QuboleDbSourceDAO quboleDAO = dbi.onDemand(QuboleDbSourceDAO.class);
-    DataSource dataSource = jdbcDAO.find(idToUpdate);
+    DataSource dataSource = jdbcDAO.find(idToUpdate, connection.getDSSet().getId());
     if (dataSource == null) {
-      dataSource = quboleDAO.find(idToUpdate);
+      dataSource = quboleDAO.find(idToUpdate, connection.getDSSet().getId());
     }
     if (dataSource == null) {
       return 0;
@@ -358,7 +358,7 @@ public class QuarkDDLExecutor implements QuarkExecutor {
     DBI dbi = getDbi();
     ViewDAO viewDAO = dbi.onDemand(ViewDAO.class);
 
-    View view = viewDAO.find(idToUpdate);
+    View view = viewDAO.find(idToUpdate, connection.getDSSet().getId());
     if (view == null) {
       return 0;
     }
@@ -411,7 +411,7 @@ public class QuarkDDLExecutor implements QuarkExecutor {
       }
     }
 
-    return viewDAO.update(view);
+    return viewDAO.update(view, connection.getDSSet().getId());
   }
 
   public int executeCreateView(SqlCreateQuarkView sqlNode) throws SQLException {
@@ -488,7 +488,7 @@ public class QuarkDDLExecutor implements QuarkExecutor {
     int id = parseCondition(node.getCondition());
     DBI dbi = getDbi();
     ViewDAO viewDAO = dbi.onDemand(ViewDAO.class);
-    viewDAO.delete(id);
+    viewDAO.delete(id, connection.getDSSet().getId());
   }
 
   private List getListFromDAO(SqlShowQuark sqlNode) throws SQLException {
@@ -502,7 +502,7 @@ public class QuarkDDLExecutor implements QuarkExecutor {
         return getDataSourceList(whereClause, dbi);
       case "SHOW_VIEW":
         ViewDAO viewDAO = dbi.onDemand(ViewDAO.class);
-        return viewDAO.findByWhere(whereClause);
+        return viewDAO.findByWhere(whereClause, connection.getDSSet().getId());
       default:
         throw new SQLException("Not supported for: " + pojoType);
     }

--- a/fatjdbc/src/main/java/com/qubole/quark/fatjdbc/executor/PlanExecutor.java
+++ b/fatjdbc/src/main/java/com/qubole/quark/fatjdbc/executor/PlanExecutor.java
@@ -105,9 +105,9 @@ public class PlanExecutor {
   }
 
   private Class getPojoType(String sql) throws SQLException {
-    if (sql.startsWith("SHOW DATASOURCE ")) {
+    if (sql.startsWith("SHOW DATASOURCE")) {
       return DataSource.class;
-    } else if (sql.startsWith("SHOW VIEW ")) {
+    } else if (sql.startsWith("SHOW VIEW")) {
       return View.class;
     }
     throw new SQLException("Unable to determine POJO for: " + sql);

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLMetaDataTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLMetaDataTest.java
@@ -39,8 +39,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DDLMetaDataTest {
   private static final Logger log = LoggerFactory.getLogger(DDLMetaDataTest.class);
 
-  private static final String dbSchemaUrl = "jdbc:h2:mem:DDLMetaDataTest;DB_CLOSE_DELAY=-1";
-  private static final String inputUrl = "jdbc:h2:mem:DDLMetaDataTest1;DB_CLOSE_DELAY=-1";
+  private static final String dbSchemaUrl = "jdbc:h2:mem:DDLMetaDataTest;DB_CLOSE_DELAY=-1;";
+  private static final String inputUrl = "jdbc:h2:mem:DDLMetaDataTest1;DB_CLOSE_DELAY=-1;";
   protected static String h2Url;
   protected static Properties props;
   static {
@@ -69,7 +69,7 @@ public class DDLMetaDataTest {
 
     Statement stmt = dbConnection.createStatement();
     String sql = "insert into data_sources(name, type, url, ds_set_id, datasource_type) values "
-        + "('H2', 'H2', '" + h2Url + "', 1, 'JDBC'); insert into jdbc_sources (id, "
+        + "('SEEDED', 'H2', '" + h2Url + "', 1, 'JDBC'); insert into jdbc_sources (id, "
         + "username, password) values(1, 'sa', '');"
         + "update ds_sets set default_datasource_id = 1 where id = 1;";
 
@@ -242,9 +242,20 @@ public class DDLMetaDataTest {
     Connection connection =
         DriverManager.getConnection("jdbc:quark:fat:db:", props);
 
-    ResultSet rs = connection.createStatement().executeQuery("SHOW DATASOURCE where password = ''");
+    ResultSet rs = connection.createStatement().executeQuery("SHOW DATASOURCE");
     assertThat(rs.next()).isEqualTo(true);
-    assertThat(rs.getString("name")).isEqualToIgnoringCase("H2");
+    assertThat(rs.getString("name")).isEqualToIgnoringCase("SEEDED");
+    assertThat(rs.getString("datasource_type")).isEqualToIgnoringCase("JDBC");
+  }
+
+  @Test
+  public void testShowDataSourceLike() throws SQLException {
+    Connection connection =
+        DriverManager.getConnection("jdbc:quark:fat:db:", props);
+
+    ResultSet rs = connection.createStatement().executeQuery("SHOW DATASOURCE like 'SEEDED'");
+    assertThat(rs.next()).isEqualTo(true);
+    assertThat(rs.getString("name")).isEqualToIgnoringCase("SEEDED");
     assertThat(rs.getString("datasource_type")).isEqualToIgnoringCase("JDBC");
   }
 }

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLMetaDataTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLMetaDataTest.java
@@ -173,7 +173,7 @@ public class DDLMetaDataTest {
     assertThat(catalogList2.size())
         .isEqualTo(catalogList1.size() + 1);
 
-    String sql2 = "DROP DATASOURCE where id = 2";
+    String sql2 = "DROP DATASOURCE H2_2";
     connection.createStatement().executeUpdate(sql2);
 
     List<String> catalogList3 = new ArrayList<>();
@@ -223,7 +223,7 @@ public class DDLMetaDataTest {
     List<String> schemaList1 = new ArrayList<>();
     getSchema(connection, catalogList1, schemaList1);
 
-    String sql1 = "DROP DATASOURCE where id = 10";
+    String sql1 = "DROP DATASOURCE bogus";
     connection.createStatement().executeUpdate(sql1);
 
     List<String> catalogList2 = new ArrayList<>();

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLViewTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLViewTest.java
@@ -196,7 +196,7 @@ public class DDLViewTest {
   @Test
   public void testNonExistentDrop() throws SQLException, ClassNotFoundException {
     Class.forName("com.qubole.quark.fatjdbc.QuarkDriver");
-    String sql1 = "DROP VIEW WHERE id = 1000";
+    String sql1 = "DROP VIEW bogus";
     Connection connection = DriverManager.getConnection("jdbc:quark:fat:db:", props);
     connection.createStatement().executeUpdate(sql1);
     connection.close();
@@ -208,7 +208,7 @@ public class DDLViewTest {
     String countQuery = "select count(*) from canonical.public.web_site where web_name = 'Quark'";
     assertThat(getSize(countQuery)).isEqualTo(1);
 
-    String sql1 = "DROP VIEW where id = 1";
+    String sql1 = "DROP VIEW web_site_part";
     Connection connection = DriverManager.getConnection("jdbc:quark:fat:db:", props);
     connection.createStatement().executeUpdate(sql1);
     connection.close();

--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLViewTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLViewTest.java
@@ -221,7 +221,16 @@ public class DDLViewTest {
     Class.forName("com.qubole.quark.fatjdbc.QuarkDriver");
     Connection connection = DriverManager.getConnection("jdbc:quark:fat:db:", props);
 
-    ResultSet rs = connection.createStatement().executeQuery("SHOW VIEW WHERE ID=1");
+    ResultSet rs = connection.createStatement().executeQuery("SHOW VIEW");
+    assertThat(rs.next()).isEqualTo(true);
+  }
+
+  @Test
+  public void testShowViewLike() throws SQLException, ClassNotFoundException {
+    Class.forName("com.qubole.quark.fatjdbc.QuarkDriver");
+    Connection connection = DriverManager.getConnection("jdbc:quark:fat:db:", props);
+
+    ResultSet rs = connection.createStatement().executeQuery("SHOW VIEW LIKE 'warehouse_part'");
     assertThat(rs.next()).isEqualTo(true);
   }
 }

--- a/optimizer/src/main/codegen/data/Parser.tdd
+++ b/optimizer/src/main/codegen/data/Parser.tdd
@@ -38,7 +38,8 @@
     "SqlCreateQuarkView()",
     "SqlAlterQuarkView()",
     "SqlDropQuarkView()",
-    "SqlShowQuark()",
+    "SqlShowDataSources()",
+    "SqlShowViews()",
   ]
 
   # List of methods for parsing custom literals.

--- a/optimizer/src/main/codegen/includes/parserImpls.ftl
+++ b/optimizer/src/main/codegen/includes/parserImpls.ftl
@@ -208,31 +208,34 @@ SqlNode SqlDropQuarkView() :
 /**
  * Parses a SHOW DDL statement.
  */
-SqlNode SqlShowQuark() :
+SqlNode SqlShowDataSources() :
 {
-    SqlNode condition;
     SqlParserPos pos;
-    SqlIdentifier quarkEntity;
+    SqlNode likePattern = null;
 }
 {
-    <SHOW>
+    <SHOW> { pos = getPos(); }
+    <DATASOURCE>
+    [
+        <LIKE> { likePattern = StringLiteral(); }
+    ]
     {
-        pos = getPos();
-    }
-    (
-        <DATASOURCE>
-        {
-            quarkEntity = new SqlIdentifier("DATASOURCE", getPos());
-        }
-        |
-        <VIEW>
-        {
-            quarkEntity = new SqlIdentifier("VIEW", getPos());
-        }
-    )
-    condition = WhereOpt()
-    {
-        return new SqlShowQuark(pos, quarkEntity, condition);
+        return new SqlShowDataSources(pos, likePattern);
     }
 }
 
+SqlNode SqlShowViews() :
+{
+    SqlParserPos pos;
+    SqlNode likePattern = null;
+}
+{
+    <SHOW> { pos = getPos(); }
+    <VIEW>
+    [
+        <LIKE> { likePattern = StringLiteral(); }
+    ]
+    {
+        return new SqlShowViews(pos, likePattern);
+    }
+}

--- a/optimizer/src/main/codegen/includes/parserImpls.ftl
+++ b/optimizer/src/main/codegen/includes/parserImpls.ftl
@@ -106,13 +106,10 @@ SqlNode SqlDropQuarkDataSource() :
     SqlParserPos pos;
 }
 {
-    <DROP> <DATASOURCE>
+    <DROP> { pos = getPos(); }
+    <DATASOURCE>
     {
-        pos = getPos();
-    }
-    condition = WhereOpt()
-    {
-        return new SqlDropQuarkDataSource(pos, condition);
+        return new SqlDropQuarkDataSource(pos, CompoundIdentifier());
     }
 }
 
@@ -195,13 +192,10 @@ SqlNode SqlDropQuarkView() :
     SqlParserPos pos;
 }
 {
-    <DROP> <VIEW>
+    <DROP> { pos = getPos(); }
+    <VIEW>
     {
-        pos = getPos();
-    }
-    condition = WhereOpt()
-    {
-        return new SqlDropQuarkView(pos, condition);
+        return new SqlDropQuarkView(pos, CompoundIdentifier());
     }
 }
 

--- a/optimizer/src/main/java/com/qubole/quark/planner/parser/sql/SqlDropQuark.java
+++ b/optimizer/src/main/java/com/qubole/quark/planner/parser/sql/SqlDropQuark.java
@@ -15,10 +15,9 @@
 package com.qubole.quark.planner.parser.sql;
 
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlOperator;
-import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.validate.SqlValidator;
@@ -32,18 +31,15 @@ import java.util.List;
  * statements for Quark.
  */
 public abstract class SqlDropQuark extends SqlCall {
-  protected SqlSpecialOperator operator;
-  protected String operatorString;
-
-  SqlNode condition;
+  SqlIdentifier identifier;
 
   //~ Constructors -----------------------------------------------------------
 
   public SqlDropQuark(
       SqlParserPos pos,
-      SqlNode condition) {
+      SqlIdentifier identifier) {
     super(pos);
-    this.condition = condition;
+    this.identifier = identifier;
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -52,22 +48,8 @@ public abstract class SqlDropQuark extends SqlCall {
     return SqlKind.OTHER_DDL;
   }
 
-  public SqlOperator getOperator() {
-    return operator;
-  }
-
   public List<SqlNode> getOperandList() {
-    return ImmutableNullableList.of(condition);
-  }
-
-  @Override public void setOperand(int i, SqlNode operand) {
-    switch (i) {
-      case 0:
-        condition = operand;
-        break;
-      default:
-        throw new AssertionError(i);
-    }
+    return ImmutableNullableList.of((SqlNode) identifier);
   }
 
   /**
@@ -76,21 +58,11 @@ public abstract class SqlDropQuark extends SqlCall {
    * @return the condition expression for the data to be deleted, or null for
    * all rows in the table
    */
-  public SqlNode getCondition() {
-    return condition;
+  public SqlIdentifier getIdentifier() {
+    return identifier;
   }
 
-  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    final SqlWriter.Frame frame =
-        writer.startList(SqlWriter.FrameTypeEnum.SELECT, operatorString, "");
-    final int opLeft = getOperator().getLeftPrec();
-    final int opRight = getOperator().getRightPrec();
-    if (condition != null) {
-      writer.sep("WHERE");
-      condition.unparse(writer, opLeft, opRight);
-    }
-    writer.endList(frame);
-  }
+  @Override public abstract void unparse(SqlWriter writer, int leftPrec, int rightPrec);
 
   public void validate(SqlValidator validator, SqlValidatorScope scope) {
     throw new UnsupportedOperationException("Validation not supported for Quark's DDL");

--- a/optimizer/src/main/java/com/qubole/quark/planner/parser/sql/SqlDropQuarkDataSource.java
+++ b/optimizer/src/main/java/com/qubole/quark/planner/parser/sql/SqlDropQuarkDataSource.java
@@ -14,9 +14,11 @@
  */
 package com.qubole.quark.planner.parser.sql;
 
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
 /**
@@ -24,14 +26,24 @@ import org.apache.calcite.sql.parser.SqlParserPos;
  * statements for Quark DataSource.
  */
 public class SqlDropQuarkDataSource extends SqlDropQuark {
-  //~ Constructors -----------------------------------------------------------
+  SqlSpecialOperator operator;
 
   public SqlDropQuarkDataSource(
       SqlParserPos pos,
-      SqlNode condition) {
-    super(pos, condition);
+      SqlIdentifier identifier) {
+    super(pos, identifier);
     operator = new SqlSpecialOperator("DROP_DATASOURCE", SqlKind.OTHER_DDL);
-    operatorString = "DROP DATASOURCE";
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return operator;
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("DROP");
+    writer.keyword("DATASOURCE");
+    identifier.unparse(writer, leftPrec, rightPrec);
   }
 }
 

--- a/optimizer/src/main/java/com/qubole/quark/planner/parser/sql/SqlDropQuarkView.java
+++ b/optimizer/src/main/java/com/qubole/quark/planner/parser/sql/SqlDropQuarkView.java
@@ -14,9 +14,11 @@
  */
 package com.qubole.quark.planner.parser.sql;
 
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
 /**
@@ -24,14 +26,23 @@ import org.apache.calcite.sql.parser.SqlParserPos;
  * statements for QuarkView.
  */
 public class SqlDropQuarkView extends SqlDropQuark {
-  //~ Constructors -----------------------------------------------------------
+  SqlSpecialOperator operator;
 
   public SqlDropQuarkView(
       SqlParserPos pos,
-      SqlNode condition) {
-    super(pos, condition);
+      SqlIdentifier identifier) {
+    super(pos, identifier);
     operator = new SqlSpecialOperator("DROP_VIEW", SqlKind.OTHER_DDL);
-    operatorString = "DROP VIEW";
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return operator;
+  }
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("DROP");
+    writer.keyword("VIEW");
+    identifier.unparse(writer, leftPrec, rightPrec);
   }
 }
 

--- a/optimizer/src/main/java/com/qubole/quark/planner/parser/sql/SqlShowDataSources.java
+++ b/optimizer/src/main/java/com/qubole/quark/planner/parser/sql/SqlShowDataSources.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2015. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.qubole.quark.planner.parser.sql;
+
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * Created by adeshr on 5/3/16.
+ */
+public class SqlShowDataSources extends SqlShowQuark {
+  String operatorString;
+
+  //~ Constructors -----------------------------------------------------------
+
+  public SqlShowDataSources(
+      SqlParserPos pos,
+      SqlNode likePattern) {
+    super(pos, likePattern);
+    operatorString = "SHOW DATASOURCE";
+  }
+
+  //~ Methods ----------------------------------------------------------------
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("SHOW");
+    writer.keyword("DATASOURCE");
+    if (likePattern != null) {
+      writer.sep("LIKE");
+      likePattern.unparse(writer, leftPrec, rightPrec);
+    }
+  }
+
+}

--- a/optimizer/src/main/java/com/qubole/quark/planner/parser/sql/SqlShowViews.java
+++ b/optimizer/src/main/java/com/qubole/quark/planner/parser/sql/SqlShowViews.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.qubole.quark.planner.parser.sql;
+
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * Created by adeshr on 5/3/16.
+ */
+public class SqlShowViews extends SqlShowQuark {
+  SqlSpecialOperator operator;
+  String operatorString;
+
+  SqlNode likePattern;
+
+  //~ Constructors -----------------------------------------------------------
+
+  public SqlShowViews(
+      SqlParserPos pos,
+      SqlNode likePattern) {
+    super(pos, likePattern);
+    this.likePattern = likePattern;
+    operator = new SqlSpecialOperator("SHOW_VIEW", SqlKind.OTHER_DDL);
+    operatorString = "SHOW VIEW";
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("SHOW");
+    writer.keyword("VIEW");
+    if (likePattern != null) {
+      writer.sep("LIKE");
+      likePattern.unparse(writer, leftPrec, rightPrec);
+    }
+  }
+}


### PR DESCRIPTION
This PR has the following two main contributions:

1. Standardize syntax of SHOW & DDL. WHERE in both these DDLS is not standard. Moreover, the way WHERE is implemented is a security flaw. It can be used for SQL Injection. I have closed this whole. WHERE makes sense for SHOW. I have added support for LIKE which is easier & safer to implement given the current architecture. These changes have to be made to CREATE and ALTER. I'll take that up as part of #80 

2. Support multi-tenancy. The main idea is to seed all DAO calls with `ds_set_id`. For e.g. check `findByName` or `findById`. Then a moved some code around and created `Connection` class to initialize and get DSSet.
