### PR TITLE
chg:usr:#93:Support AS SELECT Syntax in CREATE VIEW

### DIFF
--- a/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLViewTest.java
+++ b/fatjdbc/src/test/java/com/qubole/quark/fatjdbc/test/DDLViewTest.java
@@ -145,9 +145,8 @@ public class DDLViewTest {
     String sqlQuery = "select count(*) from warehouse as wr where wr.w_warehouse_sq_ft > 100";
     assertThat(getSize(sqlQuery)).isEqualTo(0);
 
-    String sql1 = "CREATE VIEW warehouse_part set description = \"Warehouse Partition\", cost = 0, "
-        + "query=\"select * from canonical.public.warehouse as wr where wr.w_warehouse_sq_ft > 100\", "
-        + "destination_id=2, schema_name=\"PUBLIC\", table_name = \"WAREHOUSE_PARTITION\"";
+    String sql1 = "CREATE VIEW warehouse_part STORED IN VIEWS.PUBLIC.WAREHOUSE_PARTITION" +
+        " AS select * from CANONICAL.PUBLIC.WAREHOUSE as WR where WR.W_WAREHOUSE_SQ_FT > 100";
     Connection connection = DriverManager.getConnection("jdbc:quark:fat:db:", props);
     connection.createStatement().executeUpdate(sql1);
     connection.close();

--- a/optimizer/src/main/codegen/data/Parser.tdd
+++ b/optimizer/src/main/codegen/data/Parser.tdd
@@ -28,6 +28,7 @@
   keywords: [
     "DATASOURCE",
     "SHOW",
+    "STORED",
   ]
 
   # List of methods for parsing custom SQL statements.

--- a/optimizer/src/main/codegen/includes/parserImpls.ftl
+++ b/optimizer/src/main/codegen/includes/parserImpls.ftl
@@ -135,47 +135,26 @@ SqlNode SqlDropQuarkDataSource() :
 }
 
 /**
- * Parses an CREATE VIEW statement.
+ * Parses a create view or replace existing view statement.
+ *   CREATE [OR REPLACE] VIEW view_name [ (field1, field2 ...) ] AS select_statement
  */
 SqlNode SqlCreateQuarkView() :
 {
-    SqlIdentifier identifier;
-    SqlNodeList sourceExpressionList;
-    SqlNodeList targetColumnList;
-    SqlIdentifier id;
-    SqlNode exp;
     SqlParserPos pos;
+    SqlIdentifier viewName;
+    SqlIdentifier tableName;
+    SqlNode query;
 }
 {
     <CREATE> <VIEW>
+    { pos = getPos(); }
+    viewName = SimpleIdentifier()
+    <STORED> <IN>
+    tableName = CompoundIdentifier()
+    <AS>
+    query = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
     {
-        pos = getPos();
-        targetColumnList = new SqlNodeList(pos);
-        sourceExpressionList = new SqlNodeList(pos);
-    }
-    identifier = SimpleIdentifier()
-    <SET> id = SimpleIdentifier()
-    {
-        targetColumnList.add(id);
-    }
-    <EQ> exp = Expression(ExprContext.ACCEPT_SUBQUERY)
-    {
-        sourceExpressionList.add(exp);
-    }
-    (
-        <COMMA>
-        id = SimpleIdentifier()
-        {
-            targetColumnList.add(id);
-        }
-        <EQ> exp = Expression(ExprContext.ACCEPT_SUBQUERY)
-        {
-            sourceExpressionList.add(exp);
-        }
-    ) *
-    {
-        return new SqlCreateQuarkView(pos, targetColumnList, sourceExpressionList,
-            identifier);
+        return new SqlCreateQuarkView(pos, viewName, tableName, query);
     }
 }
 


### PR DESCRIPTION
This commit changes CREATE VIEW syntax from a key-value
pair to a format which accepts destination using the
STORED keyword and AS SELECT to accept the SQL query